### PR TITLE
feat(backend): implement trip domain v2 (visibility, memberships, invites)

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/CreateTripService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/CreateTripService.kt
@@ -3,6 +3,7 @@ package com.travelcompanion.application.trip
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.trip.TripVisibility
 import com.travelcompanion.domain.user.UserId
 import org.springframework.stereotype.Service
 import java.time.Instant
@@ -28,13 +29,20 @@ class CreateTripService(
      * @param endDate The trip end date (must be >= startDate)
      * @return The created trip
      */
-    fun execute(userId: UserId, name: String, startDate: LocalDate, endDate: LocalDate): Trip {
+    fun execute(
+        userId: UserId,
+        name: String,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        visibility: TripVisibility = TripVisibility.PRIVATE,
+    ): Trip {
         val trip = Trip(
             id = TripId.generate(),
             userId = userId,
             name = name.trim(),
             startDate = startDate,
             endDate = endDate,
+            visibility = visibility,
             itineraryItems = emptyList(),
             createdAt = Instant.now(),
         )

--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/UpdateTripService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/UpdateTripService.kt
@@ -3,6 +3,7 @@ package com.travelcompanion.application.trip
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.trip.TripVisibility
 import com.travelcompanion.domain.user.UserId
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -33,6 +34,7 @@ class UpdateTripService(
         name: String?,
         startDate: LocalDate?,
         endDate: LocalDate?,
+        visibility: TripVisibility?,
     ): Trip? {
         val existing = tripRepository.findById(tripId) ?: return null
         if (existing.userId != userId) return null
@@ -45,6 +47,7 @@ class UpdateTripService(
             name = newName,
             startDate = newStart,
             endDate = newEnd,
+            visibility = visibility ?: existing.visibility,
         )
         return tripRepository.save(updated)
     }

--- a/backend/src/main/kotlin/com/travelcompanion/domain/trip/InviteStatus.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/domain/trip/InviteStatus.kt
@@ -1,0 +1,8 @@
+package com.travelcompanion.domain.trip
+
+enum class InviteStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripInvite.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripInvite.kt
@@ -1,0 +1,15 @@
+package com.travelcompanion.domain.trip
+
+import java.time.Instant
+
+data class TripInvite(
+    val email: String,
+    val role: TripRole,
+    val status: InviteStatus,
+    val createdAt: Instant,
+) {
+    init {
+        require(email.isNotBlank()) { "Invite email cannot be blank" }
+    }
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripMembership.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripMembership.kt
@@ -1,0 +1,9 @@
+package com.travelcompanion.domain.trip
+
+import com.travelcompanion.domain.user.UserId
+
+data class TripMembership(
+    val userId: UserId,
+    val role: TripRole,
+)
+

--- a/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripRole.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripRole.kt
@@ -1,0 +1,8 @@
+package com.travelcompanion.domain.trip
+
+enum class TripRole {
+    OWNER,
+    EDITOR,
+    VIEWER,
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripVisibility.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/domain/trip/TripVisibility.kt
@@ -1,0 +1,13 @@
+package com.travelcompanion.domain.trip
+
+/**
+ * Current trip visibility levels.
+ *
+ * Keep this enum as the single visibility contract so adding future values
+ * (for example link-only/shared scopes) remains a domain-level change.
+ */
+enum class TripVisibility {
+    PUBLIC,
+    PRIVATE,
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripInviteConverter.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripInviteConverter.kt
@@ -1,0 +1,57 @@
+package com.travelcompanion.infrastructure.persistence
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.travelcompanion.domain.trip.InviteStatus
+import com.travelcompanion.domain.trip.TripInvite
+import com.travelcompanion.domain.trip.TripRole
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import java.time.Instant
+
+@Converter
+class TripInviteConverter : AttributeConverter<List<TripInvite>, String> {
+
+    private val objectMapper = ObjectMapper().apply {
+        registerModule(JavaTimeModule())
+        registerModule(KotlinModule.Builder().build())
+    }
+
+    private val typeRef = object : TypeReference<List<TripInviteDto>>() {}
+
+    override fun convertToDatabaseColumn(attribute: List<TripInvite>?): String {
+        if (attribute == null || attribute.isEmpty()) return "[]"
+        val dtos = attribute.map {
+            TripInviteDto(
+                email = it.email,
+                role = it.role.name,
+                status = it.status.name,
+                createdAt = it.createdAt.toString(),
+            )
+        }
+        return objectMapper.writeValueAsString(dtos)
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): List<TripInvite> {
+        if (dbData == null || dbData.isBlank()) return emptyList()
+        val dtos = objectMapper.readValue(dbData, typeRef)
+        return dtos.map {
+            TripInvite(
+                email = it.email,
+                role = TripRole.valueOf(it.role),
+                status = InviteStatus.valueOf(it.status),
+                createdAt = Instant.parse(it.createdAt),
+            )
+        }
+    }
+
+    data class TripInviteDto(
+        val email: String,
+        val role: String,
+        val status: String,
+        val createdAt: String,
+    )
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripJpaEntity.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripJpaEntity.kt
@@ -1,6 +1,8 @@
 package com.travelcompanion.infrastructure.persistence
 
 import com.travelcompanion.domain.trip.ItineraryItem
+import com.travelcompanion.domain.trip.TripInvite
+import com.travelcompanion.domain.trip.TripMembership
 import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
@@ -36,6 +38,19 @@ class TripJpaEntity(
 
     @Column(name = "end_date", nullable = false)
     var endDate: LocalDate,
+
+    @Column(name = "visibility", nullable = false)
+    var visibility: String,
+
+    @Column(name = "memberships", nullable = false, columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Convert(converter = TripMembershipConverter::class)
+    var memberships: MutableList<TripMembership> = mutableListOf(),
+
+    @Column(name = "invites", nullable = false, columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Convert(converter = TripInviteConverter::class)
+    var invites: MutableList<TripInvite> = mutableListOf(),
 
     @Column(name = "itinerary_items", nullable = false, columnDefinition = "jsonb")
     @JdbcTypeCode(SqlTypes.JSON)

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripMembershipConverter.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/TripMembershipConverter.kt
@@ -1,0 +1,49 @@
+package com.travelcompanion.infrastructure.persistence
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.travelcompanion.domain.trip.TripMembership
+import com.travelcompanion.domain.trip.TripRole
+import com.travelcompanion.domain.user.UserId
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class TripMembershipConverter : AttributeConverter<List<TripMembership>, String> {
+
+    private val objectMapper = ObjectMapper().apply {
+        registerModule(KotlinModule.Builder().build())
+    }
+
+    private val typeRef = object : TypeReference<List<TripMembershipDto>>() {}
+
+    override fun convertToDatabaseColumn(attribute: List<TripMembership>?): String {
+        if (attribute == null || attribute.isEmpty()) return "[]"
+        val dtos = attribute.map {
+            TripMembershipDto(
+                userId = it.userId.toString(),
+                role = it.role.name,
+            )
+        }
+        return objectMapper.writeValueAsString(dtos)
+    }
+
+    override fun convertToEntityAttribute(dbData: String?): List<TripMembership> {
+        if (dbData == null || dbData.isBlank()) return emptyList()
+        val dtos = objectMapper.readValue(dbData, typeRef)
+        return dtos.map {
+            TripMembership(
+                userId = UserId.fromString(it.userId)
+                    ?: throw IllegalArgumentException("Invalid membership user id: ${it.userId}"),
+                role = TripRole.valueOf(it.role),
+            )
+        }
+    }
+
+    data class TripMembershipDto(
+        val userId: String,
+        val role: String,
+    )
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ItineraryController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ItineraryController.kt
@@ -92,6 +92,7 @@ class ItineraryController(
         name = trip.name,
         startDate = trip.startDate.toString(),
         endDate = trip.endDate.toString(),
+        visibility = trip.visibility.name,
         itineraryItems = trip.itineraryItems.map {
             ItineraryItemResponse(
                 placeName = it.placeName,

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripController.kt
@@ -51,6 +51,7 @@ class TripController(
             name = request.name,
             startDate = request.startDate,
             endDate = request.endDate,
+            visibility = request.visibility,
         )
         return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(trip))
     }
@@ -88,6 +89,7 @@ class TripController(
             name = request.name,
             startDate = request.startDate,
             endDate = request.endDate,
+            visibility = request.visibility,
         ) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
         return ResponseEntity.ok(toResponse(trip))
     }
@@ -114,6 +116,7 @@ class TripController(
         name = trip.name,
         startDate = trip.startDate.toString(),
         endDate = trip.endDate.toString(),
+        visibility = trip.visibility.name,
         itineraryItems = trip.itineraryItems.map {
             ItineraryItemResponse(
                 placeName = it.placeName,

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/dto/TripDto.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/dto/TripDto.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.interfaces.rest.dto
 
+import com.travelcompanion.domain.trip.TripVisibility
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.NotBlank
@@ -19,6 +20,8 @@ data class CreateTripRequest(
 
     @field:NotNull(message = "End date is required")
     val endDate: LocalDate,
+
+    val visibility: TripVisibility = TripVisibility.PRIVATE,
 )
 
 /**
@@ -28,6 +31,7 @@ data class UpdateTripRequest(
     val name: String? = null,
     val startDate: LocalDate? = null,
     val endDate: LocalDate? = null,
+    val visibility: TripVisibility? = null,
 )
 
 /**
@@ -38,6 +42,7 @@ data class TripResponse(
     val name: String,
     val startDate: String,
     val endDate: String,
+    val visibility: String,
     val itineraryItems: List<ItineraryItemResponse>,
     val createdAt: String,
 )

--- a/backend/src/main/resources/db/migration/V3__add_trip_visibility_memberships_invites.sql
+++ b/backend/src/main/resources/db/migration/V3__add_trip_visibility_memberships_invites.sql
@@ -1,0 +1,15 @@
+ALTER TABLE trips
+    ADD COLUMN visibility VARCHAR(32) NOT NULL DEFAULT 'PRIVATE',
+    ADD COLUMN memberships JSONB NOT NULL DEFAULT '[]',
+    ADD COLUMN invites JSONB NOT NULL DEFAULT '[]';
+
+-- Backfill existing rows so the legacy owner is represented as an OWNER membership.
+UPDATE trips
+SET memberships = jsonb_build_array(
+    jsonb_build_object(
+        'userId', user_id::text,
+        'role', 'OWNER'
+    )
+)
+WHERE memberships = '[]'::jsonb;
+

--- a/backend/src/test/kotlin/com/travelcompanion/integration/TripControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/TripControllerIntegrationTest.kt
@@ -34,15 +34,17 @@ class TripControllerIntegrationTest {
             jsonPath("$.name") { value("Summer Trip") }
             jsonPath("$.startDate") { value("2026-08-08") }
             jsonPath("$.endDate") { value("2026-08-16") }
+            jsonPath("$.visibility") { value("PRIVATE") }
         }
 
         mockMvc.put("/trips/$tripId") {
             header("Authorization", "Bearer $token")
             contentType = MediaType.APPLICATION_JSON
-            content = """{"name":"Updated Trip"}"""
+            content = """{"name":"Updated Trip","visibility":"PUBLIC"}"""
         }.andExpect {
             status { isOk() }
             jsonPath("$.name") { value("Updated Trip") }
+            jsonPath("$.visibility") { value("PUBLIC") }
         }
 
         mockMvc.get("/trips") {


### PR DESCRIPTION
## Summary\n- implement trip domain v2 constructs for visibility, memberships, roles, and invite states\n- persist new trip fields via JSONB converters and Flyway migration V3\n- expose trip visibility in create/update/read REST contracts\n- add domain and integration tests for visibility and new trip model semantics\n\nCloses #3