### PR TITLE
feat(backend): add auditability baseline for write actions

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditActorResolver.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditActorResolver.kt
@@ -1,0 +1,15 @@
+package com.travelcompanion.infrastructure.audit
+
+import com.travelcompanion.domain.user.UserId
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class AuditActorResolver {
+
+    fun currentActorId(): UserId? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal as? String ?: return null
+        return UserId.fromString(principal)
+    }
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditEventWriter.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditEventWriter.kt
@@ -1,0 +1,47 @@
+package com.travelcompanion.infrastructure.audit
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.travelcompanion.infrastructure.persistence.AuditEventJpaEntity
+import com.travelcompanion.infrastructure.persistence.SpringDataAuditEventRepository
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.UUID
+
+@Component
+class AuditEventWriter(
+    private val repo: SpringDataAuditEventRepository,
+    private val objectMapper: ObjectMapper,
+    private val actorResolver: AuditActorResolver,
+) {
+
+    fun record(
+        action: String,
+        entityType: String,
+        entityId: String,
+        beforeState: Any? = null,
+        afterState: Any? = null,
+        metadata: Map<String, Any?> = emptyMap(),
+    ) {
+        val metadataNode = toJsonNode(metadata) as? ObjectNode ?: objectMapper.createObjectNode()
+        val event = AuditEventJpaEntity(
+            id = UUID.randomUUID(),
+            actorId = actorResolver.currentActorId()?.value,
+            action = action,
+            entityType = entityType,
+            entityId = entityId,
+            occurredAt = Instant.now(),
+            beforeState = toJsonNode(beforeState),
+            afterState = toJsonNode(afterState),
+            metadata = metadataNode,
+        )
+        repo.save(event)
+    }
+
+    private fun toJsonNode(value: Any?): JsonNode? {
+        if (value == null) return null
+        return objectMapper.valueToTree(value)
+    }
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditQueryService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/audit/AuditQueryService.kt
@@ -1,0 +1,54 @@
+package com.travelcompanion.infrastructure.audit
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.persistence.SpringDataAuditEventRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import java.time.Instant
+
+@Service
+class AuditQueryService(
+    private val repo: SpringDataAuditEventRepository,
+) {
+
+    fun search(
+        entityType: String?,
+        entityId: String?,
+        actorId: UserId?,
+        limit: Int,
+    ): List<AuditEventView> {
+        val safeLimit = limit.coerceIn(1, 500)
+        return repo.search(
+            entityType = entityType,
+            entityId = entityId,
+            actorId = actorId?.value,
+            pageable = PageRequest.of(0, safeLimit),
+        ).map { entity ->
+            AuditEventView(
+                id = entity.id.toString(),
+                actorId = entity.actorId?.toString(),
+                action = entity.action,
+                entityType = entity.entityType,
+                entityId = entity.entityId,
+                occurredAt = entity.occurredAt,
+                beforeState = entity.beforeState,
+                afterState = entity.afterState,
+                metadata = entity.metadata,
+            )
+        }
+    }
+}
+
+data class AuditEventView(
+    val id: String,
+    val actorId: String?,
+    val action: String,
+    val entityType: String,
+    val entityId: String,
+    val occurredAt: Instant,
+    val beforeState: JsonNode?,
+    val afterState: JsonNode?,
+    val metadata: JsonNode,
+)
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/AuditEventJpaEntity.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/AuditEventJpaEntity.kt
@@ -1,0 +1,47 @@
+package com.travelcompanion.infrastructure.persistence
+
+import com.fasterxml.jackson.databind.JsonNode
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "audit_events")
+class AuditEventJpaEntity(
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    val id: UUID,
+
+    @Column(name = "actor_id")
+    val actorId: UUID?,
+
+    @Column(name = "action", nullable = false)
+    val action: String,
+
+    @Column(name = "entity_type", nullable = false)
+    val entityType: String,
+
+    @Column(name = "entity_id", nullable = false)
+    val entityId: String,
+
+    @Column(name = "occurred_at", nullable = false, updatable = false)
+    val occurredAt: Instant,
+
+    @Column(name = "before_state", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    val beforeState: JsonNode? = null,
+
+    @Column(name = "after_state", columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    val afterState: JsonNode? = null,
+
+    @Column(name = "metadata", nullable = false, columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    val metadata: JsonNode,
+)
+

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/JpaExpenseRepository.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/JpaExpenseRepository.kt
@@ -4,6 +4,7 @@ import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
 import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.infrastructure.audit.AuditEventWriter
 import org.springframework.stereotype.Repository
 
 /**
@@ -15,12 +16,28 @@ import org.springframework.stereotype.Repository
 @Repository
 class JpaExpenseRepository(
     private val springRepo: SpringDataExpenseRepository,
+    private val auditEventWriter: AuditEventWriter,
 ) : ExpenseRepository {
 
     override fun save(expense: Expense): Expense {
+        val existing = springRepo.findById(expense.id.value).orElse(null)?.let { toDomain(it) }
         val entity = toEntity(expense)
         val saved = springRepo.save(entity)
-        return toDomain(saved)
+        val savedDomain = toDomain(saved)
+
+        auditEventWriter.record(
+            action = if (existing == null) "EXPENSE_CREATED" else "EXPENSE_UPDATED",
+            entityType = "EXPENSE",
+            entityId = savedDomain.id.toString(),
+            beforeState = existing,
+            afterState = savedDomain,
+            metadata = mapOf(
+                "tripId" to savedDomain.tripId.toString(),
+                "currency" to savedDomain.currency,
+            ),
+        )
+
+        return savedDomain
     }
 
     override fun findById(id: ExpenseId): Expense? =
@@ -30,7 +47,20 @@ class JpaExpenseRepository(
         springRepo.findByTripId(tripId.value).map { toDomain(it) }
 
     override fun deleteById(id: ExpenseId) {
+        val existing = findById(id)
         springRepo.deleteById(id.value)
+        if (existing != null) {
+            auditEventWriter.record(
+                action = "EXPENSE_DELETED",
+                entityType = "EXPENSE",
+                entityId = existing.id.toString(),
+                beforeState = existing,
+                metadata = mapOf(
+                    "tripId" to existing.tripId.toString(),
+                    "currency" to existing.currency,
+                ),
+            )
+        }
     }
 
     private fun toEntity(expense: Expense) = ExpenseJpaEntity(

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/JpaTripRepository.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/JpaTripRepository.kt
@@ -7,6 +7,7 @@ import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.trip.TripVisibility
 import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.audit.AuditEventWriter
 import org.springframework.stereotype.Repository
 
 /**
@@ -18,12 +19,40 @@ import org.springframework.stereotype.Repository
 @Repository
 class JpaTripRepository(
     private val springRepo: SpringDataTripRepository,
+    private val auditEventWriter: AuditEventWriter,
 ) : TripRepository {
 
     override fun save(trip: Trip): Trip {
+        val existing = springRepo.findById(trip.id.value).orElse(null)?.let { toDomain(it) }
         val entity = toEntity(trip)
         val saved = springRepo.save(entity)
-        return toDomain(saved)
+        val savedDomain = toDomain(saved)
+
+        val metadata = mapOf(
+            "aggregate" to "trip",
+            "itineraryItemCount" to savedDomain.itineraryItems.size,
+        )
+        if (existing == null) {
+            auditEventWriter.record(
+                action = "TRIP_CREATED",
+                entityType = "TRIP",
+                entityId = savedDomain.id.toString(),
+                afterState = savedDomain,
+                metadata = metadata,
+            )
+        } else {
+            auditEventWriter.record(
+                action = "TRIP_UPDATED",
+                entityType = "TRIP",
+                entityId = savedDomain.id.toString(),
+                beforeState = existing,
+                afterState = savedDomain,
+                metadata = metadata,
+            )
+            recordDerivedAudit(existing, savedDomain)
+        }
+
+        return savedDomain
     }
 
     override fun findById(id: TripId): Trip? =
@@ -33,7 +62,17 @@ class JpaTripRepository(
         springRepo.findByUserIdOrderByCreatedAtDesc(userId.value).map { toDomain(it) }
 
     override fun deleteById(id: TripId) {
+        val existing = findById(id)
         springRepo.deleteById(id.value)
+        if (existing != null) {
+            auditEventWriter.record(
+                action = "TRIP_DELETED",
+                entityType = "TRIP",
+                entityId = id.toString(),
+                beforeState = existing,
+                metadata = mapOf("aggregate" to "trip"),
+            )
+        }
     }
 
     override fun existsByIdAndUserId(tripId: TripId, userId: UserId): Boolean =
@@ -53,6 +92,63 @@ class JpaTripRepository(
             createdAt = trip.createdAt,
         )
         return entity
+    }
+
+    private fun recordDerivedAudit(before: Trip, after: Trip) {
+        if (before.memberships != after.memberships) {
+            auditEventWriter.record(
+                action = "MEMBER_WRITE",
+                entityType = "MEMBER",
+                entityId = after.id.toString(),
+                beforeState = before.memberships,
+                afterState = after.memberships,
+                metadata = mapOf("tripId" to after.id.toString()),
+            )
+        }
+
+        if (before.invites != after.invites) {
+            auditEventWriter.record(
+                action = "INVITE_WRITE",
+                entityType = "INVITE",
+                entityId = after.id.toString(),
+                beforeState = before.invites,
+                afterState = after.invites,
+                metadata = mapOf("tripId" to after.id.toString()),
+            )
+        }
+
+        if (before.itineraryItems != after.itineraryItems) {
+            auditEventWriter.record(
+                action = "ITEM_WRITE",
+                entityType = "ITEM",
+                entityId = "${after.id}:itinerary",
+                beforeState = before.itineraryItems,
+                afterState = after.itineraryItems,
+                metadata = mapOf("tripId" to after.id.toString()),
+            )
+
+            auditEventWriter.record(
+                action = "DAY_WRITE",
+                entityType = "DAY",
+                entityId = after.id.toString(),
+                beforeState = before.itineraryItems.groupBy { it.date.toString() },
+                afterState = after.itineraryItems.groupBy { it.date.toString() },
+                metadata = mapOf("tripId" to after.id.toString()),
+            )
+
+            auditEventWriter.record(
+                action = "LIST_WRITE",
+                entityType = "LIST",
+                entityId = "${after.id}:places_to_visit",
+                beforeState = before.itineraryItems,
+                afterState = after.itineraryItems,
+                metadata = mapOf(
+                    "tripId" to after.id.toString(),
+                    "listName" to "Places To Visit",
+                    "note" to "Single-list itinerary baseline",
+                ),
+            )
+        }
     }
 
     private fun toDomain(entity: TripJpaEntity): Trip {

--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/SpringDataAuditEventRepository.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/persistence/SpringDataAuditEventRepository.kt
@@ -1,0 +1,27 @@
+package com.travelcompanion.infrastructure.persistence
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface SpringDataAuditEventRepository : JpaRepository<AuditEventJpaEntity, UUID> {
+
+    @Query(
+        """
+        SELECT e FROM AuditEventJpaEntity e
+        WHERE (:entityType IS NULL OR e.entityType = :entityType)
+          AND (:entityId IS NULL OR e.entityId = :entityId)
+          AND (:actorId IS NULL OR e.actorId = :actorId)
+        ORDER BY e.occurredAt DESC
+        """
+    )
+    fun search(
+        @Param("entityType") entityType: String?,
+        @Param("entityId") entityId: String?,
+        @Param("actorId") actorId: UUID?,
+        pageable: Pageable,
+    ): List<AuditEventJpaEntity>
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/AuditController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/AuditController.kt
@@ -1,0 +1,41 @@
+package com.travelcompanion.interfaces.rest
+
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.audit.AuditQueryService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/audit/events")
+class AuditController(
+    private val auditQueryService: AuditQueryService,
+) {
+
+    @GetMapping
+    fun search(
+        authentication: Authentication,
+        @RequestParam(required = false) entityType: String?,
+        @RequestParam(required = false) entityId: String?,
+        @RequestParam(required = false) actorId: String?,
+        @RequestParam(required = false, defaultValue = "100") limit: Int,
+    ): ResponseEntity<Any> {
+        authentication.principal as? String ?: return ResponseEntity.status(401).build()
+        val parsedActor = actorId?.let {
+            UserId.fromString(it) ?: return ResponseEntity.badRequest().body(
+                mapOf("message" to "Invalid actorId")
+            )
+        }
+
+        val events = auditQueryService.search(
+            entityType = entityType,
+            entityId = entityId,
+            actorId = parsedActor,
+            limit = limit,
+        )
+        return ResponseEntity.ok(events)
+    }
+}

--- a/backend/src/main/resources/db/migration/V4__create_audit_events.sql
+++ b/backend/src/main/resources/db/migration/V4__create_audit_events.sql
@@ -1,0 +1,16 @@
+CREATE TABLE audit_events (
+    id UUID PRIMARY KEY,
+    actor_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+    action VARCHAR(100) NOT NULL,
+    entity_type VARCHAR(100) NOT NULL,
+    entity_id VARCHAR(255) NOT NULL,
+    occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    before_state JSONB NULL,
+    after_state JSONB NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX idx_audit_events_occurred_at_desc ON audit_events(occurred_at DESC);
+CREATE INDEX idx_audit_events_entity ON audit_events(entity_type, entity_id);
+CREATE INDEX idx_audit_events_actor_id ON audit_events(actor_id);
+

--- a/backend/src/test/kotlin/com/travelcompanion/infrastructure/audit/AuditEventWriterTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/infrastructure/audit/AuditEventWriterTest.kt
@@ -1,0 +1,82 @@
+package com.travelcompanion.infrastructure.audit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.travelcompanion.infrastructure.persistence.AuditEventJpaEntity
+import com.travelcompanion.infrastructure.persistence.SpringDataAuditEventRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.UUID
+
+class AuditEventWriterTest {
+
+    private val repo = mock<SpringDataAuditEventRepository>()
+    private val actorResolver = AuditActorResolver()
+    private val objectMapper = ObjectMapper().apply {
+        registerModule(JavaTimeModule())
+        registerModule(KotlinModule.Builder().build())
+    }
+    private val writer = AuditEventWriter(repo, objectMapper, actorResolver)
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `record stores actor action entity and snapshots`() {
+        val actorId = UUID.randomUUID().toString()
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(actorId, null, emptyList())
+
+        whenever(repo.save(any<AuditEventJpaEntity>())).thenAnswer { it.arguments[0] as AuditEventJpaEntity }
+
+        writer.record(
+            action = "TRIP_UPDATED",
+            entityType = "TRIP",
+            entityId = "trip-1",
+            beforeState = mapOf("name" to "Old"),
+            afterState = mapOf("name" to "New"),
+            metadata = mapOf("source" to "unit-test"),
+        )
+
+        val captor = argumentCaptor<AuditEventJpaEntity>()
+        verify(repo).save(captor.capture())
+        val saved = captor.firstValue
+        assertEquals("TRIP_UPDATED", saved.action)
+        assertEquals("TRIP", saved.entityType)
+        assertEquals("trip-1", saved.entityId)
+        assertEquals(actorId, saved.actorId?.toString())
+        assertEquals("Old", saved.beforeState?.get("name")?.asText())
+        assertEquals("New", saved.afterState?.get("name")?.asText())
+        assertEquals("unit-test", saved.metadata.get("source").asText())
+        assertNotNull(saved.occurredAt)
+    }
+
+    @Test
+    fun `record supports anonymous actor`() {
+        whenever(repo.save(any<AuditEventJpaEntity>())).thenAnswer { it.arguments[0] as AuditEventJpaEntity }
+
+        writer.record(
+            action = "SYSTEM_WRITE",
+            entityType = "SYSTEM",
+            entityId = "bootstrap",
+            metadata = mapOf("scope" to "test"),
+        )
+
+        val captor = argumentCaptor<AuditEventJpaEntity>()
+        verify(repo).save(captor.capture())
+        assertEquals(null, captor.firstValue.actorId)
+    }
+}
+


### PR DESCRIPTION
## Summary\n- add audit event persistence schema and query support\n- capture actor/action/entity/timestamp with before/after snapshots and metadata for backend write operations\n- instrument trip, itinerary-related aggregate writes, expense writes, and user writes\n- expose /audit/events endpoint to inspect audit records locally\n- add focused unit tests for audit writer behavior\n\nCloses #5