### PR TITLE
feat(backend): enforce trip owner invariants in domain/application layer

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/ManageTripMembershipService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/ManageTripMembershipService.kt
@@ -1,0 +1,32 @@
+package com.travelcompanion.application.trip
+
+import com.travelcompanion.domain.trip.Trip
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.user.UserId
+import org.springframework.stereotype.Service
+
+@Service
+class ManageTripMembershipService(
+    private val tripRepository: TripRepository,
+) {
+
+    fun addOwner(tripId: TripId, actorUserId: UserId, targetUserId: UserId): Trip? {
+        val trip = tripRepository.findById(tripId) ?: return null
+        val updated = trip.addOwner(actorUserId, targetUserId)
+        return tripRepository.save(updated)
+    }
+
+    fun removeMember(tripId: TripId, actorUserId: UserId, targetUserId: UserId): Trip? {
+        val trip = tripRepository.findById(tripId) ?: return null
+        val updated = trip.removeMember(actorUserId, targetUserId)
+        return tripRepository.save(updated)
+    }
+
+    fun leaveTrip(tripId: TripId, memberUserId: UserId, successorOwnerUserId: UserId? = null): Trip? {
+        val trip = tripRepository.findById(tripId) ?: return null
+        val updated = trip.leaveTrip(memberUserId, successorOwnerUserId)
+        return tripRepository.save(updated)
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/ManageTripMembershipServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/ManageTripMembershipServiceTest.kt
@@ -1,0 +1,55 @@
+package com.travelcompanion.application.trip
+
+import com.travelcompanion.domain.trip.Trip
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.user.UserId
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDate
+
+class ManageTripMembershipServiceTest {
+
+    private val repository = mock<TripRepository>()
+    private val service = ManageTripMembershipService(repository)
+    private val tripId = TripId.generate()
+    private val ownerId = UserId.generate()
+
+    @Test
+    fun `addOwner returns null when trip not found`() {
+        whenever(repository.findById(tripId)).thenReturn(null)
+
+        val result = service.addOwner(tripId, ownerId, UserId.generate())
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `addOwner saves updated trip`() {
+        val targetOwner = UserId.generate()
+        val trip = createTrip()
+        whenever(repository.findById(tripId)).thenReturn(trip)
+        whenever(repository.save(any())).thenAnswer { it.arguments[0] as Trip }
+
+        val result = service.addOwner(tripId, ownerId, targetOwner)
+
+        assertNotNull(result)
+        verify(repository).save(any())
+    }
+
+    private fun createTrip() = Trip(
+        id = tripId,
+        userId = ownerId,
+        name = "Trip",
+        startDate = LocalDate.of(2026, 1, 1),
+        endDate = LocalDate.of(2026, 1, 5),
+        createdAt = Instant.now(),
+    )
+}
+


### PR DESCRIPTION
## Summary
- enforce core owner invariants in `Trip` aggregate and application layer workflows
- implement domain operations for owner management: `addOwner`, `removeMember`, and `leaveTrip`
- codify required rules:
  - at least one owner is always required
  - owners can add owners
  - owners cannot remove other owners
  - primary owner must assign another owner before leaving
- add focused domain/application tests for new ownership rules

Closes #10
