### PR TITLE
docs: fix markdownlint fenced-code language tags

### DIFF
--- a/docs/EXECUTION_PROTOCOL.md
+++ b/docs/EXECUTION_PROTOCOL.md
@@ -51,7 +51,7 @@ Each PR must include:
 ## Suggested Prompt Template
 Use this when starting an agent task:
 
-```
+```text
 Work on issue #<id>.
 Branch: feat/issue-<id>-<slug>
 Scope: <backend only|frontend only|specific paths>
@@ -69,7 +69,7 @@ Deliver:
 ## Queue Mode Prompt (Backend/Frontend)
 Use this when you want the agent to continuously pick work from the backlog.
 
-```
+```text
 Queue mode enabled.
 
 Global rules:


### PR DESCRIPTION
Addresses CodeRabbit feedback on PR #46 by adding language tags to fenced code blocks in docs/EXECUTION_PROTOCOL.md.