### PR TITLE
docs(backend): update expense KDoc for canWrite permission model

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/CreateExpenseService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/CreateExpenseService.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 /**
  * Handles the use case of creating an expense for a trip.
  *
- * Validates that the trip exists and belongs to the user before adding the expense.
+ * Validates that the trip exists and the user has write access before adding the expense.
  */
 @Service
 class CreateExpenseService(
@@ -26,12 +26,12 @@ class CreateExpenseService(
      * Creates a new expense for the trip.
      *
      * @param tripId The trip ID
-     * @param userId The user creating the expense (must own the trip)
+     * @param userId The user creating the expense (must have write access: OWNER or EDITOR)
      * @param amount The expense amount
      * @param currency The currency code (e.g., USD)
      * @param description Optional description
      * @param date The expense date
-     * @return The created expense, or null if trip not found/not owned
+     * @return The created expense, or null if trip is not found or trip.canWrite(userId) is false
      */
     fun execute(
         tripId: TripId,

--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/UpdateExpenseService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/UpdateExpenseService.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 /**
  * Handles the use case of updating an expense.
  *
- * Validates that the expense exists and the trip belongs to the user.
+ * Validates that the expense exists and the user has write access to the trip.
  */
 @Service
 class UpdateExpenseService(
@@ -24,12 +24,12 @@ class UpdateExpenseService(
      * Updates an expense.
      *
      * @param expenseId The expense ID
-     * @param userId The requesting user (must own the trip)
+     * @param userId The requesting user (must have write access: OWNER or EDITOR)
      * @param amount New amount (optional)
      * @param currency New currency (optional)
      * @param description New description (optional)
      * @param date New date (optional)
-     * @return The updated expense, or null if not found/not owned
+     * @return The updated expense, or null if not found or trip.canWrite(userId) is false
      */
     fun execute(
         expenseId: ExpenseId,


### PR DESCRIPTION
## Summary\n- update CreateExpenseService KDoc to describe write-access requirement (OWNER/EDITOR)\n- update UpdateExpenseService KDoc to describe write-access requirement and 	rip.canWrite(userId) behavior\n- remove outdated ownership wording from both services\n\n## Scope\n- backend docs only\n\n## Tests\n- cd backend && ./gradlew test\n\n## Link\n- follow-up for review feedback on #50