### PR TITLE
fix(backend): resolve PR53 review threads

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/LinkPendingInvitesOnRegistrationService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/LinkPendingInvitesOnRegistrationService.kt
@@ -5,12 +5,14 @@ import com.travelcompanion.domain.trip.TripMembership
 import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.user.User
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class LinkPendingInvitesOnRegistrationService(
     private val tripRepository: TripRepository,
 ) {
 
+    @Transactional
     fun execute(user: User) {
         val inviteTrips = tripRepository.findByInviteEmail(user.email)
         inviteTrips.forEach { trip ->

--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/TripCollaborationAccessDeniedException.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/TripCollaborationAccessDeniedException.kt
@@ -1,0 +1,3 @@
+package com.travelcompanion.application.trip
+
+class TripCollaborationAccessDeniedException(message: String) : RuntimeException(message)

--- a/backend/src/main/kotlin/com/travelcompanion/application/user/RegisterUserService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/user/RegisterUserService.kt
@@ -6,6 +6,7 @@ import com.travelcompanion.domain.user.UserId
 import com.travelcompanion.domain.user.UserRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 /**
@@ -30,6 +31,7 @@ class RegisterUserService(
      * @return The created user (without password hash in typical DTO mapping)
      * @throws EmailAlreadyExistsException if the email is already registered
      */
+    @Transactional
     fun execute(email: String, password: String, displayName: String): User {
         val normalizedEmail = email.trim().lowercase()
         if (userRepository.existsByEmail(normalizedEmail)) {

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.interfaces.rest
 
+import com.travelcompanion.application.trip.TripCollaborationAccessDeniedException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -15,6 +16,12 @@ class GlobalExceptionHandler {
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ErrorResponse> {
         val message = ex.message ?: "Invalid request"
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse(message))
+    }
+
+    @ExceptionHandler(TripCollaborationAccessDeniedException::class)
+    fun handleTripCollaborationAccessDenied(ex: TripCollaborationAccessDeniedException): ResponseEntity<ErrorResponse> {
+        val message = ex.message ?: "Forbidden"
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ErrorResponse(message))
     }
 
     @ExceptionHandler(DateTimeParseException::class)

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripCollaboratorController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripCollaboratorController.kt
@@ -36,8 +36,11 @@ class TripCollaboratorController(
     ): ResponseEntity<Any> {
         val requester = requireUserId(authentication) ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
+        if (!manageTripMembershipService.existsTrip(id)) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        }
         val trip = manageTripMembershipService.getCollaborators(id, requester)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            ?: return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
 
         return ResponseEntity.ok(
             CollaboratorsResponse(

--- a/backend/src/test/kotlin/com/travelcompanion/integration/TripCollaboratorControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/TripCollaboratorControllerIntegrationTest.kt
@@ -105,6 +105,20 @@ class TripCollaboratorControllerIntegrationTest {
         }
     }
 
+    @Test
+    fun `non owner gets forbidden when requesting collaborators`() {
+        val ownerToken = registerAndGetToken()
+        val tripId = createTrip(ownerToken, "Private Team Trip", "2026-12-10", "2026-12-12")
+        val viewer = registerAndGetAuth()
+        addMembership(tripId, viewer.second, TripRole.VIEWER)
+
+        mockMvc.get("/trips/$tripId/collaborators") {
+            header("Authorization", "Bearer ${viewer.first}")
+        }.andExpect {
+            status { isForbidden() }
+        }
+    }
+
     private fun registerAndGetToken(): String = registerAndGetAuth().first
 
     private fun registerAndGetAuth(): Pair<String, UserId> {


### PR DESCRIPTION
## Summary
Follow-up stacked fixes for review threads on #53.

### Addressed
- Added transactional boundaries for registration + invite linking
- Added explicit access-denied exception mapped to HTTP 403
- Prevented owner demotion edge cases in invite/member role updates
- Improved collaborators endpoint semantics (404 when trip missing, 403 when not owner)
- Added test coverage for these scenarios

## Tests
- `cd backend && ./gradlew test`
