### PR TITLE
fix(backend): guard invite path against last-owner self demotion

### DIFF
--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/ManageTripMembershipServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/ManageTripMembershipServiceTest.kt
@@ -188,6 +188,20 @@ class ManageTripMembershipServiceTest {
     }
 
     @Test
+    fun `invite cannot demote self when user is last owner`() {
+        val existingOwnerUser = createUser(email = "owner@example.com", id = ownerId)
+        val trip = createTrip(
+            memberships = listOf(TripMembership(ownerId, TripRole.OWNER))
+        )
+        whenever(repository.findById(tripId)).thenReturn(trip)
+        whenever(userRepository.findByEmail("owner@example.com")).thenReturn(existingOwnerUser)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            service.inviteMember(tripId, ownerId, "owner@example.com", TripRole.EDITOR)
+        }
+    }
+
+    @Test
     fun `change member role cannot demote last owner`() {
         val trip = createTrip(
             memberships = listOf(TripMembership(ownerId, TripRole.OWNER))


### PR DESCRIPTION
## Summary
Follow-up for PR #54 review:
- prevent self-demotion of the last remaining OWNER in `inviteMember` existing-user path
- preserve existing guard against changing another owner's role
- add focused unit test for self-demotion scenario

## Tests
- `cd backend && ./gradlew test --tests "com.travelcompanion.application.trip.ManageTripMembershipServiceTest"`
- `cd backend && ./gradlew test`
