### PR TITLE
feat(frontend): migrate API layer to v2 trip contracts

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,5 +33,7 @@ export const api = {
     request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
   put: <T>(path: string, body: unknown) =>
     request<T>(path, { method: 'PUT', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 }

--- a/frontend/src/api/collaborators.test.ts
+++ b/frontend/src/api/collaborators.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '../stores/authStore'
+import {
+  changeInviteRole,
+  fetchCollaborators,
+  inviteMember,
+  leaveTrip,
+  removeInvite,
+} from './collaborators'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('collaborators api', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    useAuthStore.setState({ token: null, user: null })
+  })
+
+  it('fetches collaborators with auth token (happy path)', async () => {
+    useAuthStore.setState({ token: 'token-2' })
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        memberships: [{ userId: 'user-1', role: 'OWNER' }],
+        invites: [{ email: 'viewer@example.com', role: 'VIEWER', status: 'PENDING' }],
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCollaborators('trip-1')
+
+    expect(result.memberships[0]?.role).toBe('OWNER')
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-1/collaborators',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-2',
+        }),
+      })
+    )
+  })
+
+  it('accepts empty memberships and invites (empty state)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ memberships: [], invites: [] })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchCollaborators('trip-empty')
+
+    expect(result.memberships).toEqual([])
+    expect(result.invites).toEqual([])
+  })
+
+  it('omits auth header for anonymous caller (permission variant)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ error: 'Unauthorized' }, 401)
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchCollaborators('trip-1')).rejects.toThrow('Unauthorized')
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = requestInit.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('throws API validation message when invite payload is invalid (validation failure)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ message: 'Email must be valid' }, 400)
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      inviteMember('trip-1', { email: 'bad-email', role: 'VIEWER' })
+    ).rejects.toThrow('Email must be valid')
+  })
+
+  it('encodes email query string on invite role changes (edge case)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ memberships: [], invites: [] })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await changeInviteRole('trip-1', 'test+one@example.com', { role: 'EDITOR' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-1/invites/role?email=test%2Bone%40example.com',
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  })
+
+  it('uses successor query parameter only when provided (regression)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ memberships: [], invites: [] }))
+      .mockResolvedValueOnce(jsonResponse({ memberships: [], invites: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await leaveTrip('trip-1')
+    await leaveTrip('trip-1', 'user-2')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/trips/trip-1/members/me')
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      '/trips/trip-1/members/me?successorOwnerUserId=user-2'
+    )
+  })
+
+  it('encodes remove-invite email and propagates backend failures (error state)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ error: 'Only owners can manage invites' }, 403)
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(removeInvite('trip-7', 'member+old@example.com')).rejects.toThrow(
+      'Only owners can manage invites'
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-7/invites?email=member%2Bold%40example.com',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+})

--- a/frontend/src/api/collaborators.ts
+++ b/frontend/src/api/collaborators.ts
@@ -1,0 +1,81 @@
+import { api } from './client'
+
+export type TripRole = 'OWNER' | 'EDITOR' | 'VIEWER'
+export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'REVOKED'
+
+export interface Membership {
+  userId: string
+  role: TripRole
+}
+
+export interface Invite {
+  email: string
+  role: TripRole
+  status: InviteStatus
+}
+
+export interface CollaboratorsResponse {
+  memberships: Membership[]
+  invites: Invite[]
+}
+
+export interface InviteMemberRequest {
+  email: string
+  role?: TripRole
+}
+
+export interface InviteResponseRequest {
+  accept: boolean
+}
+
+export interface ChangeRoleRequest {
+  role: TripRole
+}
+
+export async function fetchCollaborators(tripId: string) {
+  return api.get<CollaboratorsResponse>(`/trips/${tripId}/collaborators`)
+}
+
+export async function inviteMember(tripId: string, data: InviteMemberRequest) {
+  return api.post<CollaboratorsResponse>(`/trips/${tripId}/invites`, data)
+}
+
+export async function respondInvite(tripId: string, data: InviteResponseRequest) {
+  return api.post<CollaboratorsResponse>(`/trips/${tripId}/invites/respond`, data)
+}
+
+export async function removeInvite(tripId: string, email: string) {
+  const encodedEmail = encodeURIComponent(email)
+  return api.delete<CollaboratorsResponse>(`/trips/${tripId}/invites?email=${encodedEmail}`)
+}
+
+export async function changeMemberRole(
+  tripId: string,
+  memberId: string,
+  data: ChangeRoleRequest
+) {
+  return api.patch<CollaboratorsResponse>(`/trips/${tripId}/members/${memberId}/role`, data)
+}
+
+export async function changeInviteRole(
+  tripId: string,
+  email: string,
+  data: ChangeRoleRequest
+) {
+  const encodedEmail = encodeURIComponent(email)
+  return api.patch<CollaboratorsResponse>(`/trips/${tripId}/invites/role?email=${encodedEmail}`, data)
+}
+
+export async function removeMember(tripId: string, memberId: string) {
+  return api.delete<CollaboratorsResponse>(`/trips/${tripId}/members/${memberId}`)
+}
+
+export async function leaveTrip(tripId: string, successorOwnerUserId?: string) {
+  if (!successorOwnerUserId) {
+    return api.delete<CollaboratorsResponse>(`/trips/${tripId}/members/me`)
+  }
+  const encodedSuccessor = encodeURIComponent(successorOwnerUserId)
+  return api.delete<CollaboratorsResponse>(
+    `/trips/${tripId}/members/me?successorOwnerUserId=${encodedSuccessor}`
+  )
+}

--- a/frontend/src/api/itinerary.test.ts
+++ b/frontend/src/api/itinerary.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '../stores/authStore'
+import {
+  addItineraryItem,
+  deleteItineraryItem,
+  fetchItineraryV2,
+  moveItineraryItem,
+} from './itinerary'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('itinerary api v2', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    useAuthStore.setState({ token: null, user: null })
+  })
+
+  it('fetches v2 itinerary with auth header (happy path)', async () => {
+    useAuthStore.setState({ token: 'token-1' })
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [{ dayNumber: 1, date: '2026-01-01', items: [] }],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchItineraryV2('trip-1')
+
+    expect(result.days).toHaveLength(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-1/itinerary/v2',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token-1',
+        }),
+      })
+    )
+  })
+
+  it('allows empty itinerary containers (empty state)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchItineraryV2('trip-1')
+
+    expect(result.days).toEqual([])
+    expect(result.placesToVisit.items).toEqual([])
+  })
+
+  it('omits auth header when user is anonymous (permission variant)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchItineraryV2('trip-2')
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = requestInit.headers as Record<string, string>
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('throws backend validation message on add failure (validation failure)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ message: 'dayNumber must be >= 1' }, 400)
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      addItineraryItem('trip-1', {
+        placeName: 'Museum',
+        latitude: 1,
+        longitude: 1,
+        dayNumber: 0,
+      })
+    ).rejects.toThrow('dayNumber must be >= 1')
+  })
+
+  it('posts move payload with ordering anchors (edge case)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await moveItineraryItem('trip-5', 'item-2', {
+      targetDayNumber: 3,
+      beforeItemId: 'item-7',
+      afterItemId: 'item-6',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-5/itinerary/v2/items/item-2/move',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    )
+    const payload = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as {
+      targetDayNumber: number
+      beforeItemId: string
+      afterItemId: string
+    }
+    expect(payload.targetDayNumber).toBe(3)
+    expect(payload.beforeItemId).toBe('item-7')
+    expect(payload.afterItemId).toBe('item-6')
+  })
+
+  it('deletes by item id path (regression: no index route)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await deleteItineraryItem('trip-9', 'item-42')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-9/itinerary/v2/items/item-42',
+      expect.objectContaining({ method: 'DELETE' })
+    )
+  })
+
+  it('surfaces status text when backend returns non-json error (error state)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: 'Internal Server Error' })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(deleteItineraryItem('trip-1', 'item-1')).rejects.toThrow(
+      'Internal Server Error'
+    )
+  })
+})

--- a/frontend/src/api/itinerary.ts
+++ b/frontend/src/api/itinerary.ts
@@ -1,26 +1,68 @@
 import { api } from './client'
-import type { Trip } from './trips'
 
-export interface ItineraryItemRequest {
+export interface ItineraryItemV2 {
+  id: string
   placeName: string
+  notes: string
+  latitude: number
+  longitude: number
+  dayNumber: number | null
+}
+
+export interface DayContainer {
+  dayNumber: number
   date: string
+  items: ItineraryItemV2[]
+}
+
+export interface PlacesToVisitContainer {
+  label: string
+  items: ItineraryItemV2[]
+}
+
+export interface ItineraryV2Response {
+  days: DayContainer[]
+  placesToVisit: PlacesToVisitContainer
+}
+
+export interface ItineraryItemV2Request {
+  placeName: string
   notes?: string
   latitude: number
   longitude: number
+  dayNumber?: number
 }
 
-export async function addItineraryItem(tripId: string, data: ItineraryItemRequest) {
-  return api.post<Trip>(`/trips/${tripId}/itinerary`, data)
+export interface MoveItineraryItemV2Request {
+  targetDayNumber?: number
+  beforeItemId?: string
+  afterItemId?: string
+}
+
+export async function fetchItineraryV2(tripId: string) {
+  return api.get<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2`)
+}
+
+export async function addItineraryItem(tripId: string, data: ItineraryItemV2Request) {
+  return api.post<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items`, data)
 }
 
 export async function updateItineraryItem(
   tripId: string,
-  index: number,
-  data: ItineraryItemRequest
+  itemId: string,
+  data: ItineraryItemV2Request
 ) {
-  return api.put<Trip>(`/trips/${tripId}/itinerary/${index}`, data)
+  return api.put<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}`, data)
 }
 
-export async function deleteItineraryItem(tripId: string, index: number) {
-  return api.delete<Trip>(`/trips/${tripId}/itinerary/${index}`)
+export async function moveItineraryItem(
+  tripId: string,
+  itemId: string,
+  data: MoveItineraryItemV2Request
+) {
+  return api.post<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}/move`, data)
+}
+
+export async function deleteItineraryItem(tripId: string, itemId: string) {
+  return api.delete<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}`)
 }


### PR DESCRIPTION
## Summary
- replace index-based itinerary API calls with v2 item-id/day-list contracts
- add collaborator/invite API client module for members and invite lifecycle operations
- update trip detail page itinerary mutations/queries to use v2 endpoints and item IDs
- add API test matrix for happy path, edge, permission, validation, empty, error, and regression scenarios

## Validation
- cd frontend && npm run lint
- cd frontend && npm run test:run
- cd frontend && npm run build

Closes #28