### PR TITLE
feat(frontend): trip edit UI permission gates

### DIFF
--- a/frontend/src/api/trips.ts
+++ b/frontend/src/api/trips.ts
@@ -5,9 +5,12 @@ export interface Trip {
   name: string
   startDate: string
   endDate: string
+  visibility: TripVisibility
   itineraryItems: ItineraryItem[]
   createdAt: string
 }
+
+export type TripVisibility = 'PUBLIC' | 'PRIVATE'
 
 export interface ItineraryItem {
   placeName: string
@@ -21,6 +24,7 @@ export interface CreateTripRequest {
   name: string
   startDate: string
   endDate: string
+  visibility?: TripVisibility
 }
 
 export async function fetchTrips() {
@@ -35,7 +39,9 @@ export async function createTrip(data: CreateTripRequest) {
   return api.post<Trip>('/trips', data)
 }
 
-export async function updateTrip(id: string, data: Partial<CreateTripRequest>) {
+export type UpdateTripRequest = Partial<CreateTripRequest>
+
+export async function updateTrip(id: string, data: UpdateTripRequest) {
   return api.put<Trip>(`/trips/${id}`, data)
 }
 


### PR DESCRIPTION
## Summary
Implements role-based UI permission gates for trip detail editing in support of #27.

## Linked Issue
Closes #27

## Scope
- In scope:
  - Trip details edit form with role-aware behavior (owner/editor)
  - Owner-only privacy control in UI
  - Role-based gating for itinerary/expense write controls
  - Test matrix updates for owner/editor/viewer/anonymous behavior
- Out of scope:
  - Backend permission model changes
  - Non-trip pages

## Changes
- Added role-aware permission model in TripDetailPage:
  - owner/editor can edit non-privacy trip fields
  - only owner can update privacy
  - viewers/anonymous see read-only trip details
- Replaced broad auth-based edit gates with role-based gates for planning/expense actions.
- Added trip update mutation and wired UI validations for trip details update.
- Extended frontend trip API typing for isibility and update payload.
- Added/updated tests to cover permission matrix and validation paths.

## Test Evidence
- [x] Frontend checks
  - Command: cd frontend && npm run lint
  - Result: passed
  - Command: cd frontend && npm run test:run
  - Result: passed (38 tests)
  - Command: cd frontend && npm run build
  - Result: passed

## Risks
- UI permissions now depend on collaborator role fetch; temporary loading states may briefly render read-only controls before role data resolves.

## Rollback
- Revert this PR commit to restore previous auth-token-based frontend gating.

## Execution Protocol Checklist
- [x] Changes are limited to allowed scope/paths.
- [x] Required checks for touched area passed.
- [x] PR opened by agent; merge left to repository owner/automation policy.
