### PR TITLE
feat(frontend): FE-ITIN-02 itinerary v2 API contracts

### DIFF
--- a/frontend/src/api/itinerary.test.ts
+++ b/frontend/src/api/itinerary.test.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAuthStore } from '../stores/authStore'
 import {
   addItineraryItem,
-  deleteItineraryItem,
+  deleteItineraryItemV2,
   fetchItineraryV2,
-  moveItineraryItem,
+  moveItineraryItemV2,
+  updateItineraryItemV2,
 } from './itinerary'
 
 function jsonResponse(body: unknown, status = 200) {
@@ -100,7 +101,7 @@ describe('itinerary api v2', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await moveItineraryItem('trip-5', 'item-2', {
+    await moveItineraryItemV2('trip-5', 'item-2', {
       targetDayNumber: 3,
       beforeItemId: 'item-7',
       afterItemId: 'item-6',
@@ -122,6 +123,31 @@ describe('itinerary api v2', () => {
     expect(payload.afterItemId).toBe('item-6')
   })
 
+  it('puts update payload to v2 item route', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        days: [],
+        placesToVisit: { label: 'Places To Visit', items: [] },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await updateItineraryItemV2('trip-3', 'item-9', {
+      placeName: 'Cafe',
+      notes: 'Lunch',
+      latitude: 48.85,
+      longitude: 2.35,
+      dayNumber: 2,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/trips/trip-3/itinerary/v2/items/item-9',
+      expect.objectContaining({
+        method: 'PUT',
+      })
+    )
+  })
+
   it('deletes by item id path (regression: no index route)', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       jsonResponse({
@@ -131,7 +157,7 @@ describe('itinerary api v2', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await deleteItineraryItem('trip-9', 'item-42')
+    await deleteItineraryItemV2('trip-9', 'item-42')
 
     expect(fetchMock).toHaveBeenCalledWith(
       '/trips/trip-9/itinerary/v2/items/item-42',
@@ -145,7 +171,7 @@ describe('itinerary api v2', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    await expect(deleteItineraryItem('trip-1', 'item-1')).rejects.toThrow(
+    await expect(deleteItineraryItemV2('trip-1', 'item-1')).rejects.toThrow(
       'Internal Server Error'
     )
   })

--- a/frontend/src/api/itinerary.ts
+++ b/frontend/src/api/itinerary.ts
@@ -1,43 +1,18 @@
 import { api } from './client'
+import type {
+  ItineraryItemV2Request,
+  ItineraryV2Response,
+  MoveItineraryItemV2Request,
+} from './types/itinerary'
 
-export interface ItineraryItemV2 {
-  id: string
-  placeName: string
-  notes: string
-  latitude: number
-  longitude: number
-  dayNumber: number | null
-}
-
-export interface DayContainer {
-  dayNumber: number
-  date: string
-  items: ItineraryItemV2[]
-}
-
-export interface PlacesToVisitContainer {
-  label: string
-  items: ItineraryItemV2[]
-}
-
-export interface ItineraryV2Response {
-  days: DayContainer[]
-  placesToVisit: PlacesToVisitContainer
-}
-
-export interface ItineraryItemV2Request {
-  placeName: string
-  notes?: string
-  latitude: number
-  longitude: number
-  dayNumber?: number
-}
-
-export interface MoveItineraryItemV2Request {
-  targetDayNumber?: number
-  beforeItemId?: string
-  afterItemId?: string
-}
+export type {
+  DayContainer,
+  ItineraryItemV2,
+  ItineraryItemV2Request,
+  ItineraryV2Response,
+  MoveItineraryItemV2Request,
+  PlacesToVisitContainer,
+} from './types/itinerary'
 
 export async function fetchItineraryV2(tripId: string) {
   return api.get<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2`)
@@ -47,7 +22,7 @@ export async function addItineraryItem(tripId: string, data: ItineraryItemV2Requ
   return api.post<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items`, data)
 }
 
-export async function updateItineraryItem(
+export async function updateItineraryItemV2(
   tripId: string,
   itemId: string,
   data: ItineraryItemV2Request
@@ -55,7 +30,7 @@ export async function updateItineraryItem(
   return api.put<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}`, data)
 }
 
-export async function moveItineraryItem(
+export async function moveItineraryItemV2(
   tripId: string,
   itemId: string,
   data: MoveItineraryItemV2Request
@@ -63,6 +38,10 @@ export async function moveItineraryItem(
   return api.post<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}/move`, data)
 }
 
-export async function deleteItineraryItem(tripId: string, itemId: string) {
+export async function deleteItineraryItemV2(tripId: string, itemId: string) {
   return api.delete<ItineraryV2Response>(`/trips/${tripId}/itinerary/v2/items/${itemId}`)
 }
+
+export const updateItineraryItem = updateItineraryItemV2
+export const moveItineraryItem = moveItineraryItemV2
+export const deleteItineraryItem = deleteItineraryItemV2

--- a/frontend/src/api/types/itinerary.ts
+++ b/frontend/src/api/types/itinerary.ts
@@ -1,0 +1,38 @@
+export interface ItineraryItemV2 {
+  id: string
+  placeName: string
+  notes: string
+  latitude: number
+  longitude: number
+  dayNumber: number | null
+}
+
+export interface DayContainer {
+  dayNumber: number
+  date: string
+  items: ItineraryItemV2[]
+}
+
+export interface PlacesToVisitContainer {
+  label: string
+  items: ItineraryItemV2[]
+}
+
+export interface ItineraryV2Response {
+  days: DayContainer[]
+  placesToVisit: PlacesToVisitContainer
+}
+
+export interface ItineraryItemV2Request {
+  placeName: string
+  notes?: string
+  latitude: number
+  longitude: number
+  dayNumber?: number
+}
+
+export interface MoveItineraryItemV2Request {
+  targetDayNumber?: number
+  beforeItemId?: string
+  afterItemId?: string
+}


### PR DESCRIPTION
## Summary\n- add dedicated DTO contracts in rontend/src/api/types/itinerary.ts\n- expose explicit v2 API methods: updateItineraryItemV2, moveItineraryItemV2, deleteItineraryItemV2\n- keep compatibility aliases for existing call sites (updateItineraryItem, moveItineraryItem, deleteItineraryItem)\n- extend API tests to cover v2 PUT route and updated v2 method usage\n\n## Testing\n- cd frontend && npm run lint\n- cd frontend && npm run test:run\n- cd frontend && npm run build\n\nCloses #65