### PR TITLE
fix(backend): restore JWT cookie auth extraction

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilter.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilter.kt
@@ -64,7 +64,9 @@ class JwtAuthenticationFilter(
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             return authHeader.substring(7).takeIf { it.isNotBlank() }
         }
-        request.cookies?.find { it.name == cookieName }?.value?.takeIf { it.isNotBlank() }
-        return null
+        return request.cookies
+            ?.find { it.name == cookieName }
+            ?.value
+            ?.takeIf { it.isNotBlank() }
     }
 }

--- a/backend/src/test/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilterTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,63 @@
+package com.travelcompanion.infrastructure.auth
+
+import jakarta.servlet.http.Cookie
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+
+class JwtAuthenticationFilterTest {
+
+    private val jwtService = JwtService(
+        secret = "0123456789abcdef0123456789abcdef",
+        expirationMs = 60_000,
+    )
+    private val filter = JwtAuthenticationFilter(jwtService, "access_token")
+
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `uses bearer token when header and cookie are both present`() {
+        val headerToken = jwtService.createToken("user-header", "header@example.com")
+        val cookieToken = jwtService.createToken("user-cookie", "cookie@example.com")
+        val request = MockHttpServletRequest().apply {
+            addHeader("Authorization", "Bearer $headerToken")
+            setCookies(Cookie("access_token", cookieToken))
+        }
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertEquals("user-header", SecurityContextHolder.getContext().authentication?.principal)
+    }
+
+    @Test
+    fun `authenticates using cookie token when header is absent`() {
+        val cookieToken = jwtService.createToken("user-cookie", "cookie@example.com")
+        val request = MockHttpServletRequest().apply {
+            setCookies(Cookie("access_token", cookieToken))
+        }
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertEquals("user-cookie", SecurityContextHolder.getContext().authentication?.principal)
+    }
+
+    @Test
+    fun `does not authenticate when cookie token is invalid`() {
+        val request = MockHttpServletRequest().apply {
+            setCookies(Cookie("access_token", "invalid-token"))
+        }
+
+        filter.doFilter(request, MockHttpServletResponse(), MockFilterChain())
+
+        assertNull(SecurityContextHolder.getContext().authentication)
+    }
+}
+


### PR DESCRIPTION
## Summary
- fix JWT extraction fallback so `access_token` cookie is actually used when Authorization header is absent
- preserve precedence of Bearer header over cookie token
- add focused unit tests for filter auth behavior

## Changes
- `backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilter.kt`
  - return cookie token value in `extractToken` fallback path
- `backend/src/test/kotlin/com/travelcompanion/infrastructure/auth/JwtAuthenticationFilterTest.kt` (new)
  - validates header precedence
  - validates cookie-only auth path
  - validates invalid cookie token does not authenticate

## Validation
- ? `cd backend && ./gradlew test --tests "com.travelcompanion.infrastructure.auth.JwtAuthenticationFilterTest"`
- ?? `cd backend && ./gradlew test` fails in this environment because Docker daemon is unavailable for Testcontainers integration tests (`DockerClientProviderStrategy` / `HikariPool` init failures)

Closes #76
