### PR TITLE
test(backend): add shared integration fixture toolkit

### DIFF
--- a/backend/src/test/kotlin/com/travelcompanion/support/ApiIntegrationFixture.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/support/ApiIntegrationFixture.kt
@@ -1,0 +1,52 @@
+package com.travelcompanion.support
+
+import com.travelcompanion.domain.user.UserId
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.util.UUID
+
+object ApiIntegrationFixture {
+
+    data class AuthFixture(
+        val token: String,
+        val userId: UserId,
+        val email: String,
+    )
+
+    fun register(mockMvc: MockMvc, prefix: String = "user"): AuthFixture {
+        val email = "$prefix-${UUID.randomUUID()}@example.com"
+        val response = mockMvc.post("/auth/register") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"email":"$email","password":"password123","displayName":"$prefix user"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.token") { exists() }
+            jsonPath("$.user.id") { exists() }
+        }.andReturn()
+
+        val body = response.response.contentAsString
+        val token = JsonAssertions.stringAt(body, "token")
+        val userId = UserId.fromString(JsonAssertions.stringAt(body, "user.id"))!!
+        return AuthFixture(token = token, userId = userId, email = email)
+    }
+
+    fun createTrip(
+        mockMvc: MockMvc,
+        token: String,
+        name: String = "Trip",
+        startDate: String,
+        endDate: String,
+    ): String {
+        val response = mockMvc.post("/trips") {
+            header("Authorization", "Bearer $token")
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"name":"$name","startDate":"$startDate","endDate":"$endDate"}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.id") { exists() }
+        }.andReturn()
+        return JsonAssertions.stringAt(response.response.contentAsString, "id")
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/support/JsonAssertions.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/support/JsonAssertions.kt
@@ -1,0 +1,16 @@
+package com.travelcompanion.support
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+
+object JsonAssertions {
+    private val objectMapper = ObjectMapper()
+
+    fun read(json: String): JsonNode = objectMapper.readTree(json)
+
+    fun stringAt(json: String, field: String): String {
+        val value = field.split('.').fold(read(json)) { node, segment -> node.path(segment) }
+        require(!value.isMissingNode && !value.isNull) { "Missing non-null field: $field" }
+        return value.asText()
+    }
+}


### PR DESCRIPTION
## Summary
- add shared backend integration test toolkit for auth/trip setup
- add Jackson-based JSON helper utility for deterministic field extraction
- keep scope test-only (no production code changes)

## Changes
- `backend/src/test/kotlin/com/travelcompanion/support/ApiIntegrationFixture.kt` (new)
  - `register(...)` helper returning token/user/email fixture
  - `createTrip(...)` helper for authenticated trip bootstrap
- `backend/src/test/kotlin/com/travelcompanion/support/JsonAssertions.kt` (new)
  - JSON parsing utility with nested path support (`a.b.c`)

## Validation
- ? `cd backend && ./gradlew compileTestKotlin`
- ?? `cd backend && ./gradlew test` fails in this environment because Docker/Testcontainers daemon is unavailable

Closes #83
