### PR TITLE
refactor(backend): remove unused JwtService helper

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtService.kt
@@ -59,8 +59,4 @@ class JwtService(
             .parseSignedClaims(token)
             .payload
 
-    /**
-     * Extracts the user ID from a valid JWT.
-     */
-    fun getUserIdFromToken(token: String): String = parseToken(token).subject
 }


### PR DESCRIPTION
## Summary
- remove unused `JwtService.getUserIdFromToken(...)` helper with no call sites

## Changes
- `backend/src/main/kotlin/com/travelcompanion/infrastructure/auth/JwtService.kt`
  - delete unused method

## Validation
- ? `cd backend && ./gradlew compileTestKotlin`
- ?? `cd backend && ./gradlew test` fails in this environment because Docker/Testcontainers daemon is unavailable

Closes #82
