### PR TITLE
feat(backend): standardize forbidden vs not-found semantics

### DIFF
--- a/backend/src/main/kotlin/com/travelcompanion/application/AccessResult.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/AccessResult.kt
@@ -1,0 +1,8 @@
+package com.travelcompanion.application
+
+sealed interface AccessResult<out T> {
+    data class Success<T>(val value: T) : AccessResult<T>
+    data object NotFound : AccessResult<Nothing>
+    data object Forbidden : AccessResult<Nothing>
+}
+

--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/CreateExpenseService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/CreateExpenseService.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
@@ -40,9 +41,9 @@ class CreateExpenseService(
         currency: String,
         description: String = "",
         date: LocalDate,
-    ): Expense? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Expense> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
         require(!date.isBefore(trip.startDate) && !date.isAfter(trip.endDate)) {
             "Expense date must be within trip date range (${trip.startDate} - ${trip.endDate})"
         }
@@ -57,6 +58,6 @@ class CreateExpenseService(
             date = date,
             createdAt = Instant.now(),
         )
-        return expenseRepository.save(expense)
+        return AccessResult.Success(expenseRepository.save(expense))
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/DeleteExpenseService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/DeleteExpenseService.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
 import com.travelcompanion.domain.trip.TripRepository
@@ -24,11 +25,11 @@ class DeleteExpenseService(
      * @param userId The requesting user (must own the trip)
      * @return true if deleted, false if not found/not owned
      */
-    fun execute(expenseId: ExpenseId, userId: UserId): Boolean {
-        val existing = expenseRepository.findById(expenseId) ?: return false
-        val trip = tripRepository.findById(existing.tripId) ?: return false
-        if (!trip.canWrite(userId)) return false
+    fun execute(expenseId: ExpenseId, userId: UserId): AccessResult<Unit> {
+        val existing = expenseRepository.findById(expenseId) ?: return AccessResult.NotFound
+        val trip = tripRepository.findById(existing.tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
         expenseRepository.deleteById(expenseId)
-        return true
+        return AccessResult.Success(Unit)
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/GetExpensesService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/GetExpensesService.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseRepository
 import com.travelcompanion.domain.trip.TripId
@@ -25,9 +26,9 @@ class GetExpensesService(
      * @param userId The requesting user (must own the trip)
      * @return List of expenses, or null if trip not found/not owned
      */
-    fun execute(tripId: TripId, userId: UserId): List<Expense>? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canView(userId)) return null
-        return expenseRepository.findByTripId(tripId)
+    fun execute(tripId: TripId, userId: UserId): AccessResult<List<Expense>> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canView(userId)) return AccessResult.Forbidden
+        return AccessResult.Success(expenseRepository.findByTripId(tripId))
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/application/expense/UpdateExpenseService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/expense/UpdateExpenseService.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
@@ -38,10 +39,10 @@ class UpdateExpenseService(
         currency: String?,
         description: String?,
         date: LocalDate?,
-    ): Expense? {
-        val existing = expenseRepository.findById(expenseId) ?: return null
-        val trip = tripRepository.findById(existing.tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Expense> {
+        val existing = expenseRepository.findById(expenseId) ?: return AccessResult.NotFound
+        val trip = tripRepository.findById(existing.tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
         if (date != null) {
             require(!date.isBefore(trip.startDate) && !date.isAfter(trip.endDate)) {
                 "Expense date must be within trip date range (${trip.startDate} - ${trip.endDate})"
@@ -54,6 +55,6 @@ class UpdateExpenseService(
             description = description?.trim() ?: existing.description,
             date = date ?: existing.date,
         )
-        return expenseRepository.save(updated)
+        return AccessResult.Success(expenseRepository.save(updated))
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/GetTripService.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/GetTripService.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.trip
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripRepository
@@ -23,9 +24,9 @@ class GetTripService(
      * @param userId The requesting user's ID, or null for anonymous callers
      * @return The trip, or null if not found or not readable by user
      */
-    fun execute(tripId: TripId, userId: UserId?): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canView(userId)) return null
-        return trip
+    fun execute(tripId: TripId, userId: UserId?): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canView(userId)) return AccessResult.Forbidden
+        return AccessResult.Success(trip)
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/application/trip/ItineraryV2Service.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/application/trip/ItineraryV2Service.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.trip
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripRepository
@@ -11,10 +12,10 @@ class ItineraryV2Service(
     private val tripRepository: TripRepository,
 ) {
 
-    fun get(tripId: TripId, userId: UserId): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canView(userId)) return null
-        return trip
+    fun get(tripId: TripId, userId: UserId): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canView(userId)) return AccessResult.Forbidden
+        return AccessResult.Success(trip)
     }
 
     fun addItem(
@@ -25,16 +26,16 @@ class ItineraryV2Service(
         latitude: Double,
         longitude: Double,
         dayNumber: Int?,
-    ): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
 
         val updated = if (dayNumber == null) {
             trip.addItineraryItemToPlacesToVisit(placeName, notes, latitude, longitude)
         } else {
             trip.addItineraryItemToDay(placeName, notes, latitude, longitude, dayNumber)
         }
-        return tripRepository.save(updated)
+        return AccessResult.Success(tripRepository.save(updated))
     }
 
     fun updateItem(
@@ -46,9 +47,9 @@ class ItineraryV2Service(
         latitude: Double,
         longitude: Double,
         dayNumber: Int?,
-    ): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
 
         val updated = trip.updateItineraryItemById(
             itemId = itemId,
@@ -58,19 +59,19 @@ class ItineraryV2Service(
             longitude = longitude,
             dayNumber = dayNumber,
         )
-        return tripRepository.save(updated)
+        return AccessResult.Success(tripRepository.save(updated))
     }
 
     fun removeItem(
         tripId: TripId,
         userId: UserId,
         itemId: String,
-    ): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
 
         val updated = trip.removeItineraryItemById(itemId)
-        return tripRepository.save(updated)
+        return AccessResult.Success(tripRepository.save(updated))
     }
 
     fun moveItem(
@@ -80,9 +81,9 @@ class ItineraryV2Service(
         targetDayNumber: Int?,
         beforeItemId: String?,
         afterItemId: String?,
-    ): Trip? {
-        val trip = tripRepository.findById(tripId) ?: return null
-        if (!trip.canWrite(userId)) return null
+    ): AccessResult<Trip> {
+        val trip = tripRepository.findById(tripId) ?: return AccessResult.NotFound
+        if (!trip.canWrite(userId)) return AccessResult.Forbidden
 
         val updated = trip.moveItineraryItem(
             itemId = itemId,
@@ -90,7 +91,7 @@ class ItineraryV2Service(
             beforeItemId = beforeItemId,
             afterItemId = afterItemId,
         )
-        return tripRepository.save(updated)
+        return AccessResult.Success(tripRepository.save(updated))
     }
 
 }

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ItineraryController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ItineraryController.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.interfaces.rest
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.application.trip.ItineraryV2Service
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.interfaces.rest.dto.ItineraryItemV2Request
@@ -36,8 +37,11 @@ class ItineraryController(
         val userId = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = itineraryV2Service.get(id, userId) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(ItineraryResponseMapper.toV2Response(trip))
+        return when (val result = itineraryV2Service.get(id, userId)) {
+            is AccessResult.Success -> ResponseEntity.ok(ItineraryResponseMapper.toV2Response(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PostMapping("/v2/items")
@@ -49,7 +53,7 @@ class ItineraryController(
         val userId = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = itineraryV2Service.addItem(
+        return when (val result = itineraryV2Service.addItem(
             tripId = id,
             userId = userId,
             placeName = request.placeName,
@@ -57,8 +61,13 @@ class ItineraryController(
             latitude = request.latitude,
             longitude = request.longitude,
             dayNumber = request.dayNumber,
-        ) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.status(HttpStatus.CREATED).body(ItineraryResponseMapper.toV2Response(trip))
+        )) {
+            is AccessResult.Success -> ResponseEntity.status(HttpStatus.CREATED).body(
+                ItineraryResponseMapper.toV2Response(result.value)
+            )
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PutMapping("/v2/items/{itemId}")
@@ -71,7 +80,7 @@ class ItineraryController(
         val userId = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = itineraryV2Service.updateItem(
+        return when (val result = itineraryV2Service.updateItem(
             tripId = id,
             userId = userId,
             itemId = itemId,
@@ -80,8 +89,11 @@ class ItineraryController(
             latitude = request.latitude,
             longitude = request.longitude,
             dayNumber = request.dayNumber,
-        ) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(ItineraryResponseMapper.toV2Response(trip))
+        )) {
+            is AccessResult.Success -> ResponseEntity.ok(ItineraryResponseMapper.toV2Response(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PostMapping("/v2/items/{itemId}/move")
@@ -94,15 +106,18 @@ class ItineraryController(
         val userId = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = itineraryV2Service.moveItem(
+        return when (val result = itineraryV2Service.moveItem(
             tripId = id,
             userId = userId,
             itemId = itemId,
             targetDayNumber = request.targetDayNumber,
             beforeItemId = request.beforeItemId,
             afterItemId = request.afterItemId,
-        ) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(ItineraryResponseMapper.toV2Response(trip))
+        )) {
+            is AccessResult.Success -> ResponseEntity.ok(ItineraryResponseMapper.toV2Response(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @DeleteMapping("/v2/items/{itemId}")
@@ -114,11 +129,14 @@ class ItineraryController(
         val userId = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = itineraryV2Service.removeItem(
+        return when (val result = itineraryV2Service.removeItem(
             tripId = id,
             userId = userId,
             itemId = itemId,
-        ) ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(ItineraryResponseMapper.toV2Response(trip))
+        )) {
+            is AccessResult.Success -> ResponseEntity.ok(ItineraryResponseMapper.toV2Response(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 }

--- a/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripCollaboratorController.kt
+++ b/backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripCollaboratorController.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.interfaces.rest
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.application.trip.ManageTripMembershipService
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.user.UserId
@@ -37,13 +38,11 @@ class TripCollaboratorController(
         val requester = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        if (!manageTripMembershipService.existsTrip(id)) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        return when (val result = manageTripMembershipService.getCollaborators(id, requester)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
         }
-        val trip = manageTripMembershipService.getCollaborators(id, requester)
-            ?: return ResponseEntity.status(HttpStatus.FORBIDDEN).build()
-
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
     }
 
     @PostMapping("/invites")
@@ -55,9 +54,11 @@ class TripCollaboratorController(
         val actor = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.inviteMember(id, actor, request.email, request.role)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.inviteMember(id, actor, request.email, request.role)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PostMapping("/invites/respond")
@@ -69,9 +70,11 @@ class TripCollaboratorController(
         val actor = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.respondToInvite(id, actor, request.accept)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.respondToInvite(id, actor, request.accept)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @DeleteMapping("/invites")
@@ -83,9 +86,11 @@ class TripCollaboratorController(
         val actor = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.removePendingOrDeclinedInvite(id, actor, email)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.removePendingOrDeclinedInvite(id, actor, email)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PatchMapping("/members/{memberId}/role")
@@ -99,9 +104,11 @@ class TripCollaboratorController(
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
         val targetUserId = UserId.fromString(memberId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.changeMemberRole(id, actor, targetUserId, request.role)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.changeMemberRole(id, actor, targetUserId, request.role)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @PatchMapping("/invites/role")
@@ -114,9 +121,11 @@ class TripCollaboratorController(
         val actor = authPrincipalResolver.userId(authentication)
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.changeInviteRole(id, actor, email, request.role)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.changeInviteRole(id, actor, email, request.role)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @DeleteMapping("/members/{memberId}")
@@ -129,9 +138,11 @@ class TripCollaboratorController(
             ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
         val id = TripId.fromString(tripId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
         val target = UserId.fromString(memberId) ?: return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
-        val trip = manageTripMembershipService.removeMember(id, actor, target)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.removeMember(id, actor, target)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 
     @DeleteMapping("/members/me")
@@ -148,8 +159,10 @@ class TripCollaboratorController(
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build()
         }
 
-        val trip = manageTripMembershipService.leaveTrip(id, actor, successor)
-            ?: return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
-        return ResponseEntity.ok(CollaboratorResponseMapper.toResponse(trip))
+        return when (val result = manageTripMembershipService.leaveTrip(id, actor, successor)) {
+            is AccessResult.Success -> ResponseEntity.ok(CollaboratorResponseMapper.toResponse(result.value))
+            AccessResult.NotFound -> ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+            AccessResult.Forbidden -> ResponseEntity.status(HttpStatus.FORBIDDEN).build()
+        }
     }
 }

--- a/backend/src/test/kotlin/com/travelcompanion/application/expense/CreateExpenseServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/expense/CreateExpenseServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseRepository
 import com.travelcompanion.domain.trip.Trip
@@ -9,7 +10,7 @@ import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.user.UserId
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -43,7 +44,7 @@ class CreateExpenseServiceTest {
             date = LocalDate.of(2026, 1, 2),
         )
 
-        assertNotNull(result)
+        assertNotNull((result as AccessResult.Success).value)
         verify(expenseRepository).save(any())
     }
 
@@ -59,7 +60,7 @@ class CreateExpenseServiceTest {
             date = LocalDate.of(2026, 1, 2),
         )
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
         verify(expenseRepository, never()).save(any())
     }
 

--- a/backend/src/test/kotlin/com/travelcompanion/application/expense/DeleteExpenseServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/expense/DeleteExpenseServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
@@ -9,8 +10,7 @@ import com.travelcompanion.domain.trip.TripMembership
 import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.user.UserId
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -38,7 +38,7 @@ class DeleteExpenseServiceTest {
 
         val deleted = service.execute(expenseId, editorId)
 
-        assertTrue(deleted)
+        assertEquals(AccessResult.Success(Unit), deleted)
         verify(expenseRepository).deleteById(expenseId)
     }
 
@@ -49,7 +49,7 @@ class DeleteExpenseServiceTest {
 
         val deleted = service.execute(expenseId, viewerId)
 
-        assertFalse(deleted)
+        assertEquals(AccessResult.Forbidden, deleted)
         verify(expenseRepository, never()).deleteById(expenseId)
     }
 

--- a/backend/src/test/kotlin/com/travelcompanion/application/expense/GetExpensesServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/expense/GetExpensesServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
@@ -10,7 +11,6 @@ import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.user.UserId
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -47,7 +47,7 @@ class GetExpensesServiceTest {
 
         val result = service.execute(tripId, viewerId)
 
-        assertEquals(1, result!!.size)
+        assertEquals(1, (result as AccessResult.Success).value.size)
     }
 
     @Test
@@ -56,7 +56,7 @@ class GetExpensesServiceTest {
 
         val result = service.execute(tripId, outsiderId)
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
         verify(expenseRepository, never()).findByTripId(tripId)
     }
 

--- a/backend/src/test/kotlin/com/travelcompanion/application/expense/UpdateExpenseServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/expense/UpdateExpenseServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.expense
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.expense.Expense
 import com.travelcompanion.domain.expense.ExpenseId
 import com.travelcompanion.domain.expense.ExpenseRepository
@@ -10,7 +11,6 @@ import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.user.UserId
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -49,7 +49,7 @@ class UpdateExpenseServiceTest {
             date = null,
         )
 
-        assertEquals("Updated", result!!.description)
+        assertEquals("Updated", (result as AccessResult.Success).value.description)
     }
 
     @Test
@@ -66,7 +66,7 @@ class UpdateExpenseServiceTest {
             date = null,
         )
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
         verify(expenseRepository, never()).save(any())
     }
 

--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/GetTripServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/GetTripServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.trip
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripMembership
@@ -8,7 +9,6 @@ import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.trip.TripVisibility
 import com.travelcompanion.domain.user.UserId
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -30,7 +30,7 @@ class GetTripServiceTest {
 
         val result = service.execute(tripId, null)
 
-        assertEquals(trip, result)
+        assertEquals(AccessResult.Success(trip), result)
     }
 
     @Test
@@ -40,7 +40,7 @@ class GetTripServiceTest {
 
         val result = service.execute(tripId, null)
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
     }
 
     @Test
@@ -50,7 +50,7 @@ class GetTripServiceTest {
 
         val result = service.execute(tripId, outsiderId)
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
     }
 
     @Test
@@ -60,7 +60,7 @@ class GetTripServiceTest {
 
         val result = service.execute(tripId, ownerId)
 
-        assertEquals(trip, result)
+        assertEquals(AccessResult.Success(trip), result)
     }
 
     @Test
@@ -69,7 +69,7 @@ class GetTripServiceTest {
 
         val result = service.execute(tripId, ownerId)
 
-        assertNull(result)
+        assertEquals(AccessResult.NotFound, result)
     }
 
     private fun createTrip(visibility: TripVisibility) = Trip(

--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/ItineraryV2ServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/ItineraryV2ServiceTest.kt
@@ -1,5 +1,6 @@
 package com.travelcompanion.application.trip
 
+import com.travelcompanion.application.AccessResult
 import com.travelcompanion.domain.trip.Trip
 import com.travelcompanion.domain.trip.TripId
 import com.travelcompanion.domain.trip.TripMembership
@@ -7,7 +8,7 @@ import com.travelcompanion.domain.trip.TripRepository
 import com.travelcompanion.domain.trip.TripRole
 import com.travelcompanion.domain.user.UserId
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -42,7 +43,7 @@ class ItineraryV2ServiceTest {
             dayNumber = 1,
         )
 
-        assertNotNull(result)
+        assertNotNull((result as AccessResult.Success).value)
         verify(repository).save(any())
     }
 
@@ -61,7 +62,7 @@ class ItineraryV2ServiceTest {
             dayNumber = 1,
         )
 
-        assertNull(result)
+        assertEquals(AccessResult.Forbidden, result)
         verify(repository, never()).save(any())
     }
 
@@ -72,7 +73,7 @@ class ItineraryV2ServiceTest {
 
         val result = service.get(tripId, viewerId)
 
-        assertNotNull(result)
+        assertNotNull((result as AccessResult.Success).value)
     }
 
     private fun createTrip() = Trip(


### PR DESCRIPTION
## Summary
- introduce `AccessResult` to explicitly model `Success`, `NotFound`, and `Forbidden` in backend application services
- refactor trip, collaborator, itinerary, and expense services to return explicit access outcomes instead of collapsing authorization failures into missing resources
- update REST controllers to map outcomes consistently: `TripController` keeps private-resource opacity (`Forbidden -> 404`) while collaborator/itinerary/expense endpoints return `403` for forbidden access
- update affected unit tests to validate the new access contract

## Changed Files
- `backend/src/main/kotlin/com/travelcompanion/application/AccessResult.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/trip/GetTripService.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/trip/ItineraryV2Service.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/trip/ManageTripMembershipService.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/expense/GetExpensesService.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/expense/CreateExpenseService.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/expense/UpdateExpenseService.kt`
- `backend/src/main/kotlin/com/travelcompanion/application/expense/DeleteExpenseService.kt`
- `backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripController.kt`
- `backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ItineraryController.kt`
- `backend/src/main/kotlin/com/travelcompanion/interfaces/rest/TripCollaboratorController.kt`
- `backend/src/main/kotlin/com/travelcompanion/interfaces/rest/ExpenseController.kt`
- updated unit tests under `backend/src/test/kotlin/com/travelcompanion/application/...`

## Validation
- `cd backend && ./gradlew test --tests "com.travelcompanion.application.*"`
- `cd backend && ./gradlew test --tests "com.travelcompanion.application.trip.ManageTripMembershipServiceTest" --tests "com.travelcompanion.application.trip.GetTripServiceTest" --tests "com.travelcompanion.application.trip.ItineraryV2ServiceTest" --tests "com.travelcompanion.application.expense.*"`
- `cd backend && ./gradlew test` *(fails locally due Docker/Testcontainers environment: `DockerClientProviderStrategy`; non-code environment issue)*

## Risk and Rollback
- risk: status-code contract changes can affect clients expecting legacy behavior
- mitigation: explicit test coverage for service-layer outcomes and controller mappings
- rollback: revert this PR commit to restore prior null/boolean access semantics

Closes #81
