### PR TITLE
test(backend): expand unit-test coverage matrix for core BE components

### DIFF
--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/CreateTripServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/CreateTripServiceTest.kt
@@ -1,0 +1,71 @@
+package com.travelcompanion.application.trip
+
+import com.travelcompanion.domain.trip.Trip
+import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.trip.TripRole
+import com.travelcompanion.domain.trip.TripVisibility
+import com.travelcompanion.domain.user.UserId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.LocalDate
+
+class CreateTripServiceTest {
+
+    private val tripRepository = mock<TripRepository>()
+    private val service = CreateTripService(tripRepository)
+
+    @Test
+    fun `execute trims name and persists trip`() {
+        whenever(tripRepository.save(any())).thenAnswer { it.arguments[0] as Trip }
+        val ownerId = UserId.generate()
+
+        val result = service.execute(
+            userId = ownerId,
+            name = "  Summer Trip  ",
+            startDate = LocalDate.of(2026, 7, 1),
+            endDate = LocalDate.of(2026, 7, 10),
+            visibility = TripVisibility.PUBLIC,
+        )
+
+        val tripCaptor = argumentCaptor<Trip>()
+        verify(tripRepository).save(tripCaptor.capture())
+        assertEquals("Summer Trip", tripCaptor.firstValue.name)
+        assertEquals(TripVisibility.PUBLIC, result.visibility)
+        assertTrue(result.memberships.any { it.userId == ownerId && it.role == TripRole.OWNER })
+    }
+
+    @Test
+    fun `execute throws when trimmed name is blank`() {
+        assertThrows<IllegalArgumentException> {
+            service.execute(
+                userId = UserId.generate(),
+                name = "   ",
+                startDate = LocalDate.of(2026, 7, 1),
+                endDate = LocalDate.of(2026, 7, 2),
+            )
+        }
+        verify(tripRepository, never()).save(any())
+    }
+
+    @Test
+    fun `execute throws when end date is before start date`() {
+        assertThrows<IllegalArgumentException> {
+            service.execute(
+                userId = UserId.generate(),
+                name = "Trip",
+                startDate = LocalDate.of(2026, 7, 10),
+                endDate = LocalDate.of(2026, 7, 1),
+            )
+        }
+        verify(tripRepository, never()).save(any())
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/DeleteTripServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/DeleteTripServiceTest.kt
@@ -1,0 +1,43 @@
+package com.travelcompanion.application.trip
+
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.user.UserId
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class DeleteTripServiceTest {
+
+    private val tripRepository = mock<TripRepository>()
+    private val service = DeleteTripService(tripRepository)
+
+    @Test
+    fun `execute deletes trip when owner relationship exists`() {
+        val tripId = TripId.generate()
+        val userId = UserId.generate()
+        whenever(tripRepository.existsByIdAndUserId(tripId, userId)).thenReturn(true)
+
+        val deleted = service.execute(tripId, userId)
+
+        assertTrue(deleted)
+        verify(tripRepository).deleteById(tripId)
+    }
+
+    @Test
+    fun `execute returns false when trip does not exist for user`() {
+        val tripId = TripId.generate()
+        val userId = UserId.generate()
+        whenever(tripRepository.existsByIdAndUserId(tripId, userId)).thenReturn(false)
+
+        val deleted = service.execute(tripId, userId)
+
+        assertFalse(deleted)
+        verify(tripRepository, never()).deleteById(tripId)
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/application/trip/GetTripsServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/trip/GetTripsServiceTest.kt
@@ -1,0 +1,57 @@
+package com.travelcompanion.application.trip
+
+import com.travelcompanion.domain.trip.Trip
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.trip.TripRepository
+import com.travelcompanion.domain.trip.TripVisibility
+import com.travelcompanion.domain.user.UserId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDate
+
+class GetTripsServiceTest {
+
+    private val tripRepository = mock<TripRepository>()
+    private val service = GetTripsService(tripRepository)
+
+    @Test
+    fun `execute returns trips from repository`() {
+        val userId = UserId.generate()
+        val trips = listOf(
+            trip(userId, "A", LocalDate.of(2026, 1, 1)),
+            trip(userId, "B", LocalDate.of(2026, 2, 1)),
+        )
+        whenever(tripRepository.findByUserId(userId)).thenReturn(trips)
+
+        val result = service.execute(userId)
+
+        assertEquals(trips, result)
+        verify(tripRepository).findByUserId(userId)
+    }
+
+    @Test
+    fun `execute returns empty list when user has no trips`() {
+        val userId = UserId.generate()
+        whenever(tripRepository.findByUserId(userId)).thenReturn(emptyList())
+
+        val result = service.execute(userId)
+
+        assertEquals(emptyList<Trip>(), result)
+        verify(tripRepository).findByUserId(userId)
+    }
+
+    private fun trip(ownerId: UserId, name: String, startDate: LocalDate) = Trip(
+        id = TripId.generate(),
+        userId = ownerId,
+        name = name,
+        startDate = startDate,
+        endDate = startDate.plusDays(2),
+        visibility = TripVisibility.PRIVATE,
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/application/user/LoginServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/application/user/LoginServiceTest.kt
@@ -1,0 +1,65 @@
+package com.travelcompanion.application.user
+
+import com.travelcompanion.domain.user.User
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.domain.user.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.crypto.password.PasswordEncoder
+import java.time.Instant
+
+class LoginServiceTest {
+
+    private val userRepository = mock<UserRepository>()
+    private val passwordEncoder = mock<PasswordEncoder>()
+    private val service = LoginService(userRepository, passwordEncoder)
+
+    @Test
+    fun `execute authenticates with normalized email`() {
+        val user = User(
+            id = UserId.generate(),
+            email = "test@example.com",
+            passwordHash = "hashed",
+            displayName = "Test",
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        whenever(userRepository.findByEmail("test@example.com")).thenReturn(user)
+        whenever(passwordEncoder.matches("secret", "hashed")).thenReturn(true)
+
+        val result = service.execute("  Test@Example.COM ", "secret")
+
+        assertEquals(user, result)
+        verify(userRepository).findByEmail("test@example.com")
+    }
+
+    @Test
+    fun `execute throws when email is not found`() {
+        whenever(userRepository.findByEmail("missing@example.com")).thenReturn(null)
+
+        assertThrows<InvalidCredentialsException> {
+            service.execute("missing@example.com", "secret")
+        }
+    }
+
+    @Test
+    fun `execute throws when password does not match`() {
+        val user = User(
+            id = UserId.generate(),
+            email = "test@example.com",
+            passwordHash = "hashed",
+            displayName = "Test",
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+        whenever(userRepository.findByEmail("test@example.com")).thenReturn(user)
+        whenever(passwordEncoder.matches("wrong", "hashed")).thenReturn(false)
+
+        assertThrows<InvalidCredentialsException> {
+            service.execute("test@example.com", "wrong")
+        }
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/domain/expense/ExpenseTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/domain/expense/ExpenseTest.kt
@@ -1,0 +1,63 @@
+package com.travelcompanion.domain.expense
+
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.user.UserId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+
+class ExpenseTest {
+
+    @Test
+    fun `creates expense when amount and currency are valid`() {
+        val expense = Expense(
+            id = ExpenseId.generate(),
+            tripId = TripId.generate(),
+            userId = UserId.generate(),
+            amount = BigDecimal("0.00"),
+            currency = "USD",
+            description = "Taxi",
+            date = LocalDate.of(2026, 1, 2),
+            createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        )
+
+        assertEquals("USD", expense.currency)
+        assertEquals(BigDecimal("0.00"), expense.amount)
+    }
+
+    @Test
+    fun `throws when amount is negative`() {
+        assertThrows<IllegalArgumentException> {
+            Expense(
+                id = ExpenseId.generate(),
+                tripId = TripId.generate(),
+                userId = UserId.generate(),
+                amount = BigDecimal("-1.00"),
+                currency = "USD",
+                description = "Taxi",
+                date = LocalDate.of(2026, 1, 2),
+                createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        }
+    }
+
+    @Test
+    fun `throws when currency is blank`() {
+        assertThrows<IllegalArgumentException> {
+            Expense(
+                id = ExpenseId.generate(),
+                tripId = TripId.generate(),
+                userId = UserId.generate(),
+                amount = BigDecimal("1.00"),
+                currency = "   ",
+                description = "Taxi",
+                date = LocalDate.of(2026, 1, 2),
+                createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+            )
+        }
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/infrastructure/audit/AuditQueryServiceTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/infrastructure/audit/AuditQueryServiceTest.kt
@@ -1,0 +1,75 @@
+package com.travelcompanion.infrastructure.audit
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.persistence.AuditEventJpaEntity
+import com.travelcompanion.infrastructure.persistence.SpringDataAuditEventRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.data.domain.Pageable
+import java.time.Instant
+import java.util.UUID
+
+class AuditQueryServiceTest {
+
+    private val repo = mock<SpringDataAuditEventRepository>()
+    private val service = AuditQueryService(repo)
+    private val mapper = ObjectMapper()
+
+    @Test
+    fun `search maps repository entities to views`() {
+        val actorId = UserId.generate()
+        val event = AuditEventJpaEntity(
+            id = UUID.randomUUID(),
+            actorId = actorId.value,
+            action = "TRIP_UPDATED",
+            entityType = "TRIP",
+            entityId = "trip-1",
+            occurredAt = Instant.parse("2026-01-01T00:00:00Z"),
+            beforeState = mapper.readTree("""{"name":"Old"}"""),
+            afterState = mapper.readTree("""{"name":"New"}"""),
+            metadata = mapper.readTree("""{"source":"unit"}"""),
+        )
+        whenever(repo.search(eq("TRIP"), eq("trip-1"), eq(actorId.value), any<Pageable>()))
+            .thenReturn(listOf(event))
+
+        val result = service.search("TRIP", "trip-1", actorId, 50)
+
+        assertEquals(1, result.size)
+        assertEquals(event.id.toString(), result[0].id)
+        assertEquals(actorId.toString(), result[0].actorId)
+        assertEquals("TRIP_UPDATED", result[0].action)
+        assertEquals("Old", result[0].beforeState?.get("name")?.asText())
+        assertEquals("New", result[0].afterState?.get("name")?.asText())
+        assertEquals("unit", result[0].metadata.get("source").asText())
+    }
+
+    @Test
+    fun `search coerces low limit to one`() {
+        whenever(repo.search(eq(null), eq(null), eq(null), any<Pageable>())).thenReturn(emptyList())
+
+        service.search(null, null, null, 0)
+
+        val pageableCaptor = argumentCaptor<Pageable>()
+        verify(repo).search(eq(null), eq(null), eq(null), pageableCaptor.capture())
+        assertEquals(1, pageableCaptor.firstValue.pageSize)
+    }
+
+    @Test
+    fun `search coerces high limit to five hundred`() {
+        whenever(repo.search(eq(null), eq(null), eq(null), any<Pageable>())).thenReturn(emptyList())
+
+        service.search(null, null, null, 5_000)
+
+        val pageableCaptor = argumentCaptor<Pageable>()
+        verify(repo).search(eq(null), eq(null), eq(null), pageableCaptor.capture())
+        assertEquals(500, pageableCaptor.firstValue.pageSize)
+    }
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaExpenseRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaExpenseRepositoryTest.kt
@@ -1,0 +1,142 @@
+package com.travelcompanion.infrastructure.persistence
+
+import com.travelcompanion.domain.expense.Expense
+import com.travelcompanion.domain.expense.ExpenseId
+import com.travelcompanion.domain.trip.TripId
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.audit.AuditEventWriter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.util.Optional
+
+class JpaExpenseRepositoryTest {
+
+    private val springRepo = mock<SpringDataExpenseRepository>()
+    private val auditEventWriter = mock<AuditEventWriter>()
+    private val repository = JpaExpenseRepository(springRepo, auditEventWriter)
+
+    @Test
+    fun `save writes create audit when entity does not exist`() {
+        val expense = expense()
+        whenever(springRepo.findById(expense.id.value)).thenReturn(Optional.empty())
+        whenever(springRepo.save(any<ExpenseJpaEntity>())).thenAnswer { it.arguments[0] as ExpenseJpaEntity }
+
+        val saved = repository.save(expense)
+
+        assertEquals(expense, saved)
+        verify(auditEventWriter).record(
+            action = eq("EXPENSE_CREATED"),
+            entityType = eq("EXPENSE"),
+            entityId = eq(expense.id.toString()),
+            beforeState = eq(null),
+            afterState = eq(saved),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `save writes update audit when entity already exists`() {
+        val expense = expense()
+        val existingEntity = ExpenseJpaEntity(
+            id = expense.id.value,
+            tripId = expense.tripId.value,
+            userId = expense.userId.value,
+            amount = BigDecimal("10.00"),
+            currency = "USD",
+            description = "old",
+            date = expense.date.minusDays(1),
+            createdAt = expense.createdAt.minusSeconds(60),
+        )
+        whenever(springRepo.findById(expense.id.value)).thenReturn(Optional.of(existingEntity))
+        whenever(springRepo.save(any<ExpenseJpaEntity>())).thenAnswer { it.arguments[0] as ExpenseJpaEntity }
+
+        repository.save(expense)
+
+        verify(auditEventWriter).record(
+            action = eq("EXPENSE_UPDATED"),
+            entityType = eq("EXPENSE"),
+            entityId = eq(expense.id.toString()),
+            beforeState = any<Expense>(),
+            afterState = any<Expense>(),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `deleteById records delete audit only when expense exists`() {
+        val expense = expense()
+        val existingEntity = ExpenseJpaEntity(
+            id = expense.id.value,
+            tripId = expense.tripId.value,
+            userId = expense.userId.value,
+            amount = expense.amount,
+            currency = expense.currency,
+            description = expense.description,
+            date = expense.date,
+            createdAt = expense.createdAt,
+        )
+        whenever(springRepo.findById(expense.id.value)).thenReturn(Optional.of(existingEntity))
+
+        repository.deleteById(expense.id)
+
+        verify(springRepo).deleteById(expense.id.value)
+        verify(auditEventWriter).record(
+            action = eq("EXPENSE_DELETED"),
+            entityType = eq("EXPENSE"),
+            entityId = eq(expense.id.toString()),
+            beforeState = eq(expense),
+            afterState = eq(null),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `deleteById skips delete audit when expense does not exist`() {
+        val id = ExpenseId.generate()
+        whenever(springRepo.findById(id.value)).thenReturn(Optional.empty())
+
+        repository.deleteById(id)
+
+        verify(springRepo).deleteById(id.value)
+        verify(auditEventWriter, never()).record(
+            action = eq("EXPENSE_DELETED"),
+            entityType = eq("EXPENSE"),
+            entityId = any(),
+            beforeState = any(),
+            afterState = any(),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `findById returns null when not found`() {
+        val id = ExpenseId.generate()
+        whenever(springRepo.findById(id.value)).thenReturn(Optional.empty())
+
+        val found = repository.findById(id)
+
+        assertNull(found)
+    }
+
+    private fun expense() = Expense(
+        id = ExpenseId.generate(),
+        tripId = TripId.generate(),
+        userId = UserId.generate(),
+        amount = BigDecimal("42.50"),
+        currency = "USD",
+        description = "Lunch",
+        date = LocalDate.of(2026, 1, 2),
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}
+

--- a/backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaUserRepositoryTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaUserRepositoryTest.kt
@@ -1,0 +1,114 @@
+package com.travelcompanion.infrastructure.persistence
+
+import com.travelcompanion.domain.user.User
+import com.travelcompanion.domain.user.UserId
+import com.travelcompanion.infrastructure.audit.AuditEventWriter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.Optional
+
+class JpaUserRepositoryTest {
+
+    private val springRepo = mock<SpringDataUserRepository>()
+    private val auditEventWriter = mock<AuditEventWriter>()
+    private val repository = JpaUserRepository(springRepo, auditEventWriter)
+
+    @Test
+    fun `save writes user created audit on new user`() {
+        val user = user()
+        whenever(springRepo.findById(user.id.value)).thenReturn(Optional.empty())
+        whenever(springRepo.save(any<UserJpaEntity>())).thenAnswer { it.arguments[0] as UserJpaEntity }
+
+        val saved = repository.save(user)
+
+        assertEquals(user, saved)
+        verify(auditEventWriter).record(
+            action = eq("USER_CREATED"),
+            entityType = eq("USER"),
+            entityId = eq(user.id.toString()),
+            beforeState = eq(null),
+            afterState = any<User>(),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `save writes user updated audit on existing user`() {
+        val user = user()
+        val existing = UserJpaEntity(
+            id = user.id.value,
+            email = user.email,
+            passwordHash = "old-hash",
+            displayName = "Old Name",
+            createdAt = user.createdAt.minusSeconds(120),
+        )
+        whenever(springRepo.findById(user.id.value)).thenReturn(Optional.of(existing))
+        whenever(springRepo.save(any<UserJpaEntity>())).thenAnswer { it.arguments[0] as UserJpaEntity }
+
+        repository.save(user)
+
+        verify(auditEventWriter).record(
+            action = eq("USER_UPDATED"),
+            entityType = eq("USER"),
+            entityId = eq(user.id.toString()),
+            beforeState = any<User>(),
+            afterState = any<User>(),
+            metadata = any<Map<String, Any?>>(),
+        )
+    }
+
+    @Test
+    fun `findByEmail delegates to case-insensitive spring query`() {
+        val user = user()
+        whenever(springRepo.findByEmailIgnoreCase("USER@EXAMPLE.COM")).thenReturn(
+            UserJpaEntity(
+                id = user.id.value,
+                email = user.email,
+                passwordHash = user.passwordHash,
+                displayName = user.displayName,
+                createdAt = user.createdAt,
+            )
+        )
+
+        val found = repository.findByEmail("USER@EXAMPLE.COM")
+
+        assertEquals(user.email, found?.email)
+        verify(springRepo).findByEmailIgnoreCase("USER@EXAMPLE.COM")
+    }
+
+    @Test
+    fun `findById returns null when user missing`() {
+        val id = UserId.generate()
+        whenever(springRepo.findById(id.value)).thenReturn(Optional.empty())
+
+        val found = repository.findById(id)
+
+        assertNull(found)
+    }
+
+    @Test
+    fun `existsByEmail delegates to spring repository`() {
+        whenever(springRepo.existsByEmailIgnoreCase("user@example.com")).thenReturn(true)
+
+        val exists = repository.existsByEmail("user@example.com")
+
+        assertEquals(true, exists)
+        verify(springRepo).existsByEmailIgnoreCase("user@example.com")
+    }
+
+    private fun user() = User(
+        id = UserId.generate(),
+        email = "user@example.com",
+        passwordHash = "hash",
+        displayName = "User Name",
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+    )
+}
+


### PR DESCRIPTION
## Summary
- add the full unit-test matrix requested in issue #84 across application, infrastructure, and domain layers
- cover happy paths, edge cases, and failure paths for login, trip create/delete/list, audit query mapping/limit bounds, JPA user/expense repositories, and expense domain invariants
- keep production code unchanged (tests only)

## Changed Files
- `backend/src/test/kotlin/com/travelcompanion/application/user/LoginServiceTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/application/trip/CreateTripServiceTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/application/trip/DeleteTripServiceTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/application/trip/GetTripsServiceTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/infrastructure/audit/AuditQueryServiceTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaExpenseRepositoryTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/infrastructure/persistence/JpaUserRepositoryTest.kt` (new)
- `backend/src/test/kotlin/com/travelcompanion/domain/expense/ExpenseTest.kt` (new)

## Validation
- `cd backend && ./gradlew test --tests "com.travelcompanion.application.user.LoginServiceTest" --tests "com.travelcompanion.application.trip.CreateTripServiceTest" --tests "com.travelcompanion.application.trip.DeleteTripServiceTest" --tests "com.travelcompanion.application.trip.GetTripsServiceTest" --tests "com.travelcompanion.infrastructure.audit.AuditQueryServiceTest" --tests "com.travelcompanion.infrastructure.persistence.JpaExpenseRepositoryTest" --tests "com.travelcompanion.infrastructure.persistence.JpaUserRepositoryTest" --tests "com.travelcompanion.domain.expense.ExpenseTest"` ?
- `cd backend && ./gradlew test` ? in this local environment due Docker/Testcontainers initialization (`DockerClientProviderStrategy`) in integration tests

## Risks and Rollback
- risk is low: test-only changes
- rollback by reverting this PR commit

Closes #84
