### PR TITLE
test(backend): align remaining integration tests to integ profile

### DIFF
--- a/backend/src/main/resources/application-integ.yml
+++ b/backend/src/main/resources/application-integ.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: jdbc:tc:postgresql:17:///travel_companion
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  flyway:
+    enabled: true

--- a/backend/src/test/kotlin/com/travelcompanion/integration/AuditControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/AuditControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class AuditControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/AuthIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/AuthIntegrationTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class AuthIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerIntegrationTest.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class ExpenseControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerRouteInvariantIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerRouteInvariantIntegrationTest.kt
@@ -14,7 +14,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class ExpenseControllerRouteInvariantIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/ItineraryControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/ItineraryControllerIntegrationTest.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class ItineraryControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/SecurityMatrixIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/SecurityMatrixIntegrationTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class SecurityMatrixIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/TripCollaboratorControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/TripCollaboratorControllerIntegrationTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class TripCollaboratorControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/TripControllerIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/TripControllerIntegrationTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class TripControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/kotlin/com/travelcompanion/integration/TripOwnerTransferIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/travelcompanion/integration/TripOwnerTransferIntegrationTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("integ")
 class TripOwnerTransferIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- migrate the remaining backend integration tests from `@ActiveProfiles("test")` to `@ActiveProfiles("integ")`
- add `application-integ.yml` so integration-profile tests resolve Testcontainers datasource and Flyway config consistently
- keep production code unchanged

## Changed Files
- `backend/src/test/kotlin/com/travelcompanion/integration/AuditControllerIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/AuthIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/ItineraryControllerIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/TripOwnerTransferIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerRouteInvariantIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/SecurityMatrixIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/TripCollaboratorControllerIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/ExpenseControllerIntegrationTest.kt`
- `backend/src/test/kotlin/com/travelcompanion/integration/TripControllerIntegrationTest.kt`
- `backend/src/main/resources/application-integ.yml` (new)

## Validation
- `cd backend && ./gradlew test` ? local environment Docker/Testcontainers availability issue (`DockerClientProviderStrategy`) after profile alignment
- `cd backend && ./gradlew test --tests "com.travelcompanion.integration.AuthIntegrationTest"` ? same local Docker/Testcontainers availability issue

## Risks and Rollback
- risk: low; test-configuration/profile alignment only
- rollback: revert this PR commit

Closes #96
